### PR TITLE
Add support for transliteration

### DIFF
--- a/API UI.txt
+++ b/API UI.txt
@@ -125,7 +125,7 @@ size = number, adjust the size of the border.
 color = table, {r, g, b, a}
 texture = string, edge name for SharedMedia:Fetch ("border", texture)
 
-instance:SetBarTextSettings (size, font, fixedcolor, leftcolorbyclass, rightcolorbyclass, leftoutline, rightoutline, customrighttextenabled, customrighttext, percentage_type, showposition, customlefttextenabled, customlefttext)
+instance:SetBarTextSettings (size, font, fixedcolor, leftcolorbyclass, rightcolorbyclass, leftoutline, rightoutline, customrighttextenabled, customrighttext, percentage_type, showposition, customlefttextenabled, customlefttext, translittest)
 size = number, text size
 font = string, text font, e.g "Arrial Narrow"
 fixedcolor = table with {r, b, g, a} or html color string (e.g. "blue").

--- a/Libs/LibTranslit-1.0/LibTranslit-1.0.lua
+++ b/Libs/LibTranslit-1.0/LibTranslit-1.0.lua
@@ -1,0 +1,113 @@
+local MAJOR_VERSION = "LibTranslit-1.0"
+local MINOR_VERSION = 3
+if not LibStub then
+	error(MAJOR_VERSION .. " requires LibStub.")
+end
+local lib = LibStub:NewLibrary(MAJOR_VERSION, MINOR_VERSION)
+if not lib then
+	return
+end
+
+local CyrToLat = {
+	["А"] = "A",
+	["а"] = "a",
+	["Б"] = "B",
+	["б"] = "b",
+	["В"] = "V",
+	["в"] = "v",
+	["Г"] = "G",
+	["г"] = "g",
+	["Д"] = "D",
+	["д"] = "d",
+	["Е"] = "E",
+	["е"] = "e",
+	["Ё"] = "e",
+	["ё"] = "e",
+	["Ж"] = "Zh",
+	["ж"] = "zh",
+	["З"] = "Z",
+	["з"] = "z",
+	["И"] = "I",
+	["и"] = "i",
+	["Й"] = "Y",
+	["й"] = "y",
+	["К"] = "K",
+	["к"] = "k",
+	["Л"] = "L",
+	["л"] = "l",
+	["М"] = "M",
+	["м"] = "m",
+	["Н"] = "N",
+	["н"] = "n",
+	["О"] = "O",
+	["о"] = "o",
+	["П"] = "P",
+	["п"] = "p",
+	["Р"] = "R",
+	["р"] = "r",
+	["С"] = "S",
+	["с"] = "s",
+	["Т"] = "T",
+	["т"] = "t",
+	["У"] = "U",
+	["у"] = "u",
+	["Ф"] = "F",
+	["ф"] = "f",
+	["Х"] = "Kh",
+	["х"] = "kh",
+	["Ц"] = "Ts",
+	["ц"] = "ts",
+	["Ч"] = "Ch",
+	["ч"] = "ch",
+	["Ш"] = "Sh",
+	["ш"] = "sh",
+	["Щ"] = "Shch",
+	["щ"] = "shch",
+	["Ъ"] = "",
+	["ъ"] = "",
+	["Ы"] = "Y",
+	["ы"] = "y",
+	["Ь"] = "",
+	["ь"] = "",
+	["Э"] = "E",
+	["э"] = "e",
+	["Ю"] = "Yu",
+	["ю"] = "yu",
+	["Я"] = "Ya",
+	["я"] = "ya"
+}
+
+function lib:Transliterate(str, mark)
+	if not str then
+		return ""
+	end
+
+	local mark = mark or ""
+	local tstr = ""
+	local marked = false
+	local i = 1
+
+	while i <= string.len(str) do
+		local c = str:sub(i, i)
+		local b = string.byte(c)
+
+		if b == 208 or b == 209 then
+			if marked == false then
+				tstr = tstr .. mark
+				marked = true
+			end
+			c = str:sub(i + 1, i + 1)
+			tstr = tstr .. (CyrToLat[string.char(b, string.byte(c))] or string.char(b, string.byte(c)))
+
+			i = i + 2
+		else
+			if c == " " or c == "-" then
+				marked = false
+			end
+			tstr = tstr .. c
+			i = i + 1
+		end
+	end
+
+	return tstr
+end

--- a/Libs/libs.xml
+++ b/Libs/libs.xml
@@ -18,4 +18,5 @@
 	<Include file="LibItemUpgradeInfo-1.0\LibItemUpgradeInfo-1.0.xml"/>
 	<Include file="LibGroupInSpecT-1.1\lib.xml"/>
 	<Include file="DF\load.xml"/>
+	<Include file="LibTranslit-1.0\LibTranslit-1.0.lua"/>
 </Ui>

--- a/classes/classe_damage.lua
+++ b/classes/classe_damage.lua
@@ -3,6 +3,7 @@
 
 	local _detalhes = 		_G._detalhes
 	local Loc = LibStub ("AceLocale-3.0"):GetLocale ( "Details" )
+	local Translit = LibStub ("LibTranslit-1.0")
 	local gump = 			_detalhes.gump
 	local _
 
@@ -2672,6 +2673,10 @@ local InBarIconPadding = 6
 		bar_number = bar.colocacao .. ". "
 	end
 
+	if (instance.row_info.textL_translit_text) then
+		self.displayName = Translit:Transliterate(self.displayName, "!")
+	end
+
 	if (enemy) then
 		if (arena_enemy) then
 			if (_detalhes.show_arena_role_icon) then
@@ -5150,9 +5155,9 @@ end
 				_detalhes.refresh:r_atributo_damage (actor, shadow)
 			end
 			
-			--a referência do .owner pode ter sido apagada?
-			--os 2 segmentos foram juntados porém a referência do owner de um pet criado ali em cima deve ser nula?
-			--teria que analisar se o novo objecto é de um pet e colocar a referência do owner no pet novamente, ou pelo menos verificar se a referência é valida
+			--a referÃªncia do .owner pode ter sido apagada?
+			--os 2 segmentos foram juntados porÃ©m a referÃªncia do owner de um pet criado ali em cima deve ser nula?
+			--teria que analisar se o novo objecto Ã© de um pet e colocar a referÃªncia do owner no pet novamente, ou pelo menos verificar se a referÃªncia Ã© valida
 			
 			--> tempo decorrido (captura de dados)
 				local end_time = actor.end_time

--- a/classes/classe_instancia_include.lua
+++ b/classes/classe_instancia_include.lua
@@ -191,6 +191,8 @@ _detalhes.instance_defaults = {
 				textR_separator = ",",
 			--left text bar number
 				textL_show_number = true,
+			--translit text
+				textL_translit_text = false,
 			--if text class color are false, this color will be used
 				fixed_text_color = {1, 1, 1},
 			--left text outline effect

--- a/functions/skins.lua
+++ b/functions/skins.lua
@@ -180,6 +180,7 @@ local _
 					0, -- [3]
 				},
 				["textL_show_number"] = true,
+				["textL_translit_text"] = false,
 				["textR_custom_text"] = "{data1} ({data2}, {data3}%)",
 				["texture"] = "Details Serenity",
 				["models"] = {
@@ -445,6 +446,7 @@ local _
 					0, -- [3]
 				},
 				["textL_show_number"] = true,
+				["textL_translit_text"] = false,
 				["textR_custom_text"] = "{data1} ({data2}, {data3}%)",
 				["texture"] = "BantoBar",
 				["use_spec_icons"] = true,
@@ -591,6 +593,7 @@ local _
 					0, -- [3]
 				},
 				["textL_show_number"] = true,
+				["textL_translit_text"] = false,
 				["textR_custom_text"] = "{data1} ({data2}, {data3}%)",
 				["texture"] = "Details Serenity",
 				["models"] = {
@@ -892,6 +895,7 @@ local _
 					1, -- [4]
 				},
 				["textL_show_number"] = true,
+				["textL_translit_text"] = false,
 				["fixed_texture_background_color"] = {
 					0, -- [1]
 					0.0862745098039216, -- [2]
@@ -1203,6 +1207,7 @@ local _
 				["use_spec_icons"] = true,
 				["icon_file"] = "Interface\\AddOns\\Details\\images\\spec_icons_normal_alpha",
 				["textL_show_number"] = true,
+				["textL_translit_text"] = false,
 				["texture"] = "Skyline",
 				["texture_background_file"] = "Interface\\AddOns\\Details\\images\\bar4",
 				["textR_enable_custom_text"] = false,
@@ -1535,6 +1540,7 @@ local _
 					0, -- [3]
 				},
 				["textL_show_number"] = true,
+				["textL_translit_text"] = false,
 				["textL_outline_small_color"] = {
 					0, -- [1]
 					0, -- [2]
@@ -1811,6 +1817,7 @@ local _
 					0, -- [3]
 				},
 				["textL_show_number"] = true,
+				["textL_translit_text"] = false,
 				["textR_custom_text"] = "{data1} ({data2}, {data3}%)",
 				["texture"] = "Skyline",
 				["use_spec_icons"] = true,
@@ -2028,6 +2035,7 @@ local _
 				["texture_class_colors"] = true,
 				["texture_file"] = "Interface\\AddOns\\Details\\images\\bar_background",
 				["textL_show_number"] = true,
+				["textL_translit_text"] = false,
 				["fixed_texture_color"] = {0.862745098039216,0.862745098039216,0.862745098039216,1},
 			},
 			["bars_grow_direction"] = 1,
@@ -2310,6 +2318,7 @@ local _
 					1, -- [4]
 				},
 				["textL_show_number"] = true,
+				["textL_translit_text"] = false,
 				["use_spec_icons"] = true,
 				["textR_custom_text"] = "{data1} ({data2}, {data3}%)",
 				["texture"] = "DGround",
@@ -2513,6 +2522,7 @@ local _
 					0, -- [3]
 				},
 				["textL_show_number"] = true,
+				["textL_translit_text"] = false,
 				["textL_custom_text"] = "{data1}. {data3}{data2}",
 				["textR_custom_text"] = "{data1} ({data2}, {data3}%)",
 				["fixed_texture_background_color"] = {

--- a/gumps/janela_options.lua
+++ b/gumps/janela_options.lua
@@ -6696,6 +6696,30 @@ function window:CreateFrame5()
 		
 		window:CreateLineBackground2 (frame5, "PositionNumberSlider", "PositionNumberLabel", Loc ["STRING_OPTIONS_TEXT_LPOSITION_DESC"])
 		
+
+	--> left translit text
+		g:NewSwitch (frame5, _, "$parentTranslitTextSlider", "TranslitTextSlider", 60, 20, _, _, instance.row_info.textL_translit_text, nil, nil, nil, nil, options_switch_template)
+		g:NewLabel (frame5, _, "$parentTranslitTextLabel", "TranslitTextLabel", Loc ["STRING_OPTIONS_TEXT_LTRANSLIT"], "GameFontHighlightLeft")
+		
+		frame5.TranslitTextSlider:SetPoint ("left", frame5.TranslitTextLabel, "right", 2)
+		frame5.TranslitTextSlider:SetAsCheckBox()
+		frame5.TranslitTextSlider.OnSwitch = function (self, instance, value)
+			instance:SetBarTextSettings (nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, value)
+			
+			if (_detalhes.options_group_edit and not DetailsOptionsWindow.loading_settings) then
+				for _, this_instance in ipairs (instance:GetInstanceGroup()) do
+					if (this_instance ~= instance) then
+						this_instance:SetBarTextSettings (nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, value)
+					end
+				end
+			end
+			
+			_detalhes:SendOptionsModifiedEvent (DetailsOptionsWindow.instance)
+		end
+		
+		window:CreateLineBackground2 (frame5, "TranslitTextSlider", "TranslitTextLabel", Loc ["STRING_OPTIONS_TEXT_LTRANSLIT_DESC"])
+
+
 	--> right outline
 		g:NewSwitch (frame5, _, "$parentTextRightOutlineSlider", "textRightOutlineSlider", 60, 20, _, _, instance.row_info.textR_outline, nil, nil, nil, nil, options_switch_template)
 		g:NewLabel (frame5, _, "$parentTextRightOutlineLabel", "textRightOutlineLabel", Loc ["STRING_OPTIONS_TEXT_LOUTILINE"], "GameFontHighlightLeft")
@@ -7210,8 +7234,9 @@ function window:CreateFrame5()
 			{"OutlineSmallColorLabelLeft", 2},
 			{"classColorsLeftTextLabel", 3},
 			{"PositionNumberLabel", 4},
-			{"cutomLeftTextLabel", 5, true},
-			{"cutomLeftTextEntryLabel", 6},
+			{"TranslitTextLabel", 5},
+			{"cutomLeftTextLabel", 6, true},
+			{"cutomLeftTextEntryLabel", 7},
 		}
 		
 		window:arrange_menu (frame5, left_side, x, window.top_start_at)
@@ -11461,6 +11486,9 @@ end --> if not window
 		
 		_G.DetailsOptionsWindow5PositionNumberSlider.MyObject:SetFixedParameter (editing_instance)
 		_G.DetailsOptionsWindow5PositionNumberSlider.MyObject:SetValue (editing_instance.row_info.textL_show_number)
+
+		_G.DetailsOptionsWindow5TranslitTextSlider.MyObject:SetFixedParameter (editing_instance)
+		_G.DetailsOptionsWindow5TranslitTextSlider.MyObject:SetValue (editing_instance.row_info.textL_translit_text)
 
 		_G.DetailsOptionsWindow5BracketDropdown.MyObject:SetFixedParameter (editing_instance)
 		_G.DetailsOptionsWindow5SeparatorDropdown.MyObject:SetFixedParameter (editing_instance)

--- a/gumps/janela_principal.lua
+++ b/gumps/janela_principal.lua
@@ -4128,7 +4128,7 @@ function gump:CriaNovaBarra (instancia, index)
 	return new_row
 end
 
-function _detalhes:SetBarTextSettings (size, font, fixedcolor, leftcolorbyclass, rightcolorbyclass, leftoutline, rightoutline, customrighttextenabled, customrighttext, percentage_type, showposition, customlefttextenabled, customlefttext, smalloutline_left, smalloutlinecolor_left, smalloutline_right, smalloutlinecolor_right)
+function _detalhes:SetBarTextSettings (size, font, fixedcolor, leftcolorbyclass, rightcolorbyclass, leftoutline, rightoutline, customrighttextenabled, customrighttext, percentage_type, showposition, customlefttextenabled, customlefttext, smalloutline_left, smalloutlinecolor_left, smalloutline_right, smalloutlinecolor_right, translittext)
 	
 	--> size
 	if (size) then
@@ -4213,6 +4213,11 @@ function _detalhes:SetBarTextSettings (size, font, fixedcolor, leftcolorbyclass,
 		self.row_info.textL_show_number = showposition
 	end
 	
+	--> translit text
+	if (type (translittext) == "boolean") then
+		self.row_info.textL_translit_text = translittext
+	end
+
 	self:InstanceReset()
 	self:InstanceRefreshRows()
 end


### PR DESCRIPTION
Add support for transliteration on the left text.

Add a checkbox option on the left text to translit cyrilic character: 
![image](https://user-images.githubusercontent.com/12969608/58195419-379f4900-7cc8-11e9-942d-ba8ae4042d18.png)

Before checking the option:
![image](https://user-images.githubusercontent.com/12969608/58195441-40901a80-7cc8-11e9-98ae-d24b9d9a770d.png)
After checking it:
![image](https://user-images.githubusercontent.com/12969608/58195454-471e9200-7cc8-11e9-96bb-d22666d79b66.png)

It's great for font that doesn't support cyrilic and to be able to read russian character name.

I don't really know how to add the phrase in the locale.
