### PR TITLE
bugfix healing done from unit to unit

### DIFF
--- a/core/parser.lua
+++ b/core/parser.lua
@@ -1792,11 +1792,11 @@
 			--> pet
 			if (meu_dono) then
 				meu_dono.total = meu_dono.total + cura_efetiva --> heal do pet
-				meu_dono.targets [alvo_name] = (meu_dono.targets [alvo_name] or 0) + amount
+				meu_dono.targets [alvo_name] = (meu_dono.targets [alvo_name] or 0) + cura_efetiva
 			end
 			
 			--> target amount
-			este_jogador.targets [alvo_name] = (este_jogador.targets [alvo_name] or 0) + amount
+			este_jogador.targets [alvo_name] = (este_jogador.targets [alvo_name] or 0) + cura_efetiva
 		end
 		
 		if (meu_dono) then


### PR DESCRIPTION
fixes the inaccurate numbers in healing done to a specific unit.
"amount" includes overhealing when we don't want to include it, "cura_efetiva" has the correct value.

this also fixes the main part of issue #21 