### PR TITLE
Track spell reflect damage

### DIFF
--- a/core/parser.lua
+++ b/core/parser.lua
@@ -105,6 +105,8 @@
 		local ignore_actors = {}
 	--> spell containers for special cases
 		local monk_guard_talent = {} --guard talent for bm monks
+	--> holds transitory information about reflected spells
+		local reflected = {}
 		
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 --> constants
@@ -455,6 +457,24 @@
 		--if (ignore_actors [alvo_serial]) then
 		--	return
 		--end
+
+		--> this cast may have been spell reflected
+		if (who_serial == alvo_serial) then
+			local idx = who_serial
+			if (reflected[idx] and reflected[idx].serial) then
+				--> the 'SPELL_MISSED' with type 'REFLECT' appeared first -> log the reflection
+				who_serial = reflected[idx].serial
+				who_name = reflected[idx].name
+				who_flags = reflected[idx].who_flags
+				reflected[idx] = nil
+				return parser:spell_dmg (token, time, who_serial, who_name, who_flags, alvo_serial, alvo_name, alvo_flags, alvo_flags2, spellid, spellname, spelltype, amount, -1, nil, nil, nil, nil, false, false, false, false)
+			else
+				--> otherwise log the amount for the 'SPELL_MISSED' event
+				reflected[idx] = {
+					amount = amount
+				}
+			end
+		end
 		
 		--rules of specific encounters
 		
@@ -1406,6 +1426,24 @@
 				
 			end
 		
+        --> It is non deterministic whether the 'SPELL_DAMAGE' or the 'SPELL_MISSED' log appears first. We handle both cases.
+		elseif (missType == "REFLECT") then
+				if (reflected[who_serial] and reflected[who_serial].amount > 0) then
+					--> 'SPELL_DAMAGE' was logged first -> log the reflect here
+					--> We cannot rely on amountMissed which is empty in the reflection case
+					local amount = reflected[who_serial].amount
+					reflected[who_serial] = nil
+					return parser:spell_dmg (token, time, alvo_serial, alvo_name, alvo_flags, who_serial, who_name, who_flags, nil, spellid, spellname, spelltype, amount, -1, nil, nil, nil, nil, false, false, false, false)
+				else
+					--> otherwise write out information used in the 'SPELL_DAMAGE' event
+					reflected[who_serial] = {
+						serial = alvo_serial,
+						name = alvo_name,
+						who_flags = alvo_flags,
+						amount = 0
+					}
+				end
+
 		else
 			--colocando aqui apenas pois ele confere o override dentro do damage
 			if (is_using_spellId_override) then
@@ -5137,6 +5175,7 @@ local SPELL_POWER_PAIN = SPELL_POWER_PAIN or (PowerEnum and PowerEnum.Pain) or 1
 		_table_wipe (misc_cache_petsOwners)
 		
 		_table_wipe (ignore_death)
+		_table_wipe (reflected)
 	
 		damage_cache = setmetatable ({}, _detalhes.weaktable)
 		damage_cache_pets = setmetatable ({}, _detalhes.weaktable)


### PR DESCRIPTION
closes #56 

# Overview

This changes Details so that reflected damage is attributed to the reflector and not the caster. It should work for any reflects in game as it is agnostic to the spell that applied the reflection effect. I tested it with a protection Warrior.

![WoWScrnShot_041120_014552](https://user-images.githubusercontent.com/2580396/79039037-a1755980-7bde-11ea-839e-36312270d2da.jpg)


# Motivation 

Using spell reflect properly is core to the game play of protection warriors. Without any attribution of the damage it is hard to review this performance. In addition is is part of the warriors damage that simply is not honored by other players when not attributed in details.

# Implementation

Reflected damage is announced by a `SPELL_MISSED` combat log event with the miss type set to `REFLECT`. This event does not contain the amount that was reflected (`amountMissed` is `nil`). Therefore we store the amount in the corresponding `SPELL_DAMAGE` event and use it when the reflection occurs. However, as an additional obstacle the order of the events seems to be non deterministic. Therefore this code also handles the inverse case: Store the reflecting entity on `SPELL_MISSED` and use this information on `SPELL_DAMAGE`.

