### PR TITLE
chore: added version to main toc file

### DIFF
--- a/Details.toc
+++ b/Details.toc
@@ -4,6 +4,7 @@
 ## SavedVariables: _detalhes_global
 ## SavedVariablesPerCharacter: _detalhes_database
 ## OptionalDeps: Ace3, LibSharedMedia-3.0, LibWindow-1.1, LibDBIcon-1.0, NickTag-1.0, LibDataBroker-1.1, LibItemUpgradeInfo-1.0, LibGroupInSpecT-1.1, LibCompress, LibGraph-2.0
+## Version: @project-version@
 #@no-lib-strip@
 Libs\libs.xml
 #@end-no-lib-strip@


### PR DESCRIPTION
I've added a version tag to the [toc file](https://github.com/Tercioo/Details-Damage-Meter/blob/master/Details.toc).
This is useful for many cases, one being [third party addon managers](https://github.com/casperstorm/ajour) easily can detect which version of Details! the user have installed.

Let me know what you think.