### PR TITLE
Allow for Custom Actor objects to be defined in Custom Displays

### DIFF
--- a/classes/class_custom.lua
+++ b/classes/class_custom.lua
@@ -849,7 +849,6 @@
 				value = _detalhes:GetOrderNumber(),
 				is_custom = true,
 				color = actor.color,
-				icone = actor.icon or actor.icone
 			}, atributo_custom.mt)
 			
 			new_actor.name_complement = name_complement

--- a/classes/class_custom.lua
+++ b/classes/class_custom.lua
@@ -157,7 +157,7 @@
 			
 			local okey, _total, _top, _amount = _pcall (func, combat, instance_container, instance)
 			if (not okey) then
-				_detalhes:Msg ("|cFFFF9900error on custom display function|r:", total)
+				_detalhes:Msg ("|cFFFF9900error on custom display function|r:", _total)
 				return _detalhes:EndRefresh (instance, 0, combat, combat [1])
 			end
 			
@@ -757,6 +757,9 @@
 	-- ~add
 	function atributo_custom:AddValue (actor, actortotal, checktop, name_complement)
 		local actor_table = self:GetActorTable (actor, name_complement)
+		if (not getmetatable(actor)) then
+			_setmetatable(actor,atributo_custom.mt)
+		end
 		actor_table.my_actor = actor
 		actor_table.value = actor_table.value + actortotal
 		
@@ -845,6 +848,8 @@
 				classe = class,
 				value = _detalhes:GetOrderNumber(),
 				is_custom = true,
+				color = actor.color,
+				icone = actor.icon or actor.icone
 			}, atributo_custom.mt)
 			
 			new_actor.name_complement = name_complement

--- a/classes/class_damage.lua
+++ b/classes/class_damage.lua
@@ -330,6 +330,8 @@
 				else
 					if (not is_player_class [actor.classe] and actor.flag_original and _bit_band (actor.flag_original, 0x00000020) ~= 0) then --> neutral
 						return _unpack (Details.class_colors.NEUTRAL)
+					elseif (actor.color) then
+						return _unpack(actor.color)
 					else
 						return _unpack (Details.class_colors [actor.classe or "UNKNOW"])
 					end

--- a/functions/playerclass.lua
+++ b/functions/playerclass.lua
@@ -117,8 +117,10 @@ do
 		elseif (type (class) == "string") then
 			return unpack (_detalhes.class_colors [class] or default_color)
 			
+		elseif (self.color) then
+			return unpack(self.color)
 		else
-			unpack (default_color)
+			return unpack (default_color)
 		end
 	end
 	


### PR DESCRIPTION
For the time being, Details has only allowed for already made Actor objects as suitable tables to CustomContainer:AddValue. This pull request attempts to change that somewhat by minorly changing a few key parts, as well as fixing a few bugs that I noticed along the way.

Normally, if you were to create a custom name for an 'actor' it would error because the metatable that actors have would not exist on the custom object, and so the tooltip would error when trying to run `GetClassColor`. So in order to allow for customizability, I have made it so that `GetClassColor` and `GetBarColor` both respect the `color` attribute on the custom actor object.


Is this finished? No, but this is a good starting point.

Two fixes in this that I request you add anyways is the one at line 160 in Class_Custom and 123 in PlayerClass