### PR TITLE
Removed underscores from method calls

### DIFF
--- a/Libs/DF/button.lua
+++ b/Libs/DF/button.lua
@@ -1213,7 +1213,7 @@ end
 function DF:NewColorPickButton (parent, name, member, callback, alpha, button_template)
 
 	--button
-	local button = DF:NewButton (parent, _, name, member, color_button_width, color_button_height, pickcolor, alpha, "param2", nil, nil, nil, button_template)
+	local button = DF:NewButton (parent, nil, name, member, color_button_width, color_button_height, pickcolor, alpha, "param2", nil, nil, nil, button_template)
 	button.color_callback = callback
 	button.Cancel = colorpick_cancel
 	button.SetColor = set_colorpick_color

--- a/Libs/DF/cooltip.lua
+++ b/Libs/DF/cooltip.lua
@@ -881,7 +881,7 @@ function DF:CreateCoolTip()
 				local parameterTable = CoolTip.ParametersTableMain [self.index]
 				local func = CoolTip.FunctionsTableMain [self.index]
 				--> passing nil as the first parameter was a design mistake
-				--CoolTip.FunctionsTableMain [self.index] (_, CoolTip.FixedValue, parameterTable [1], parameterTable [2], parameterTable [3], button)
+				--CoolTip.FunctionsTableMain [self.index] (nil, CoolTip.FixedValue, parameterTable [1], parameterTable [2], parameterTable [3], button)
 				local okay, errortext = pcall (func, CoolTip.Host, CoolTip.FixedValue, parameterTable [1], parameterTable [2], parameterTable [3], button)
 				if (not okay) then
 					print ("Cooltip OnClick Error:", errortext)
@@ -897,7 +897,7 @@ function DF:CreateCoolTip()
 			if (CoolTip.FunctionsTableSub [self.mainIndex] and CoolTip.FunctionsTableSub [self.mainIndex] [self.index]) then
 				local parameterTable = CoolTip.ParametersTableSub [self.mainIndex] [self.index]
 				local func = CoolTip.FunctionsTableSub [self.mainIndex] [self.index]
-				--CoolTip.FunctionsTableSub [self.mainIndex] [self.index] (_, CoolTip.FixedValue, parameterTable [1], parameterTable [2], parameterTable [3], button)
+				--CoolTip.FunctionsTableSub [self.mainIndex] [self.index] (nil, CoolTip.FixedValue, parameterTable [1], parameterTable [2], parameterTable [3], button)
 				local okay, errortext = pcall (func, CoolTip.Host, CoolTip.FixedValue, parameterTable [1], parameterTable [2], parameterTable [3], button)
 				if (not okay) then
 					print ("Cooltip OnClick Error:", errortext)

--- a/Libs/DF/fw.lua
+++ b/Libs/DF/fw.lua
@@ -755,7 +755,7 @@ end
 			end
 		end
 		
-		if (_type (v1) == "string" and _type (v2) == "table") then --> :setpoint ("left", frame, _, _, _)
+		if (_type (v1) == "string" and _type (v2) == "table") then --> :setpoint ("left", frame, nil, nil, _)
 			if (not v3 or _type (v3) == "number") then --> :setpoint ("left", frame, 10, 10)
 				v1, v2, v3, v4, v5 = v1, v2, v1, v3, v4
 			end
@@ -3375,7 +3375,7 @@ function DF:QuickDispatch (func, ...)
 	
 	if (not okay) then
 		--> trigger an error msg
-		dispatch_error (_, errortext)
+		dispatch_error (nil, errortext)
 		return
 	end
 	
@@ -3384,7 +3384,7 @@ end
 
 function DF:Dispatch (func, ...)
 	if (type (func) ~= "function") then
-		return dispatch_error (_, "Dispatch required a function.")
+		return dispatch_error (nil, "Dispatch required a function.")
 	end
 
 	local okay, result1, result2, result3, result4 = xpcall (func, geterrorhandler(), ...)

--- a/Libs/DF/panel.lua
+++ b/Libs/DF/panel.lua
@@ -394,7 +394,7 @@ DF.LayoutFrame = {
 			end
 		end
 		
-		return DF:NewLabel (self, _, "$parentRightMouseToClose", nil, "|TInterface\\TUTORIALFRAME\\UI-TUTORIAL-FRAME:"..w..":"..h..":0:1:512:512:8:70:328:409|t " .. text)
+		return DF:NewLabel (self, nil, "$parentRightMouseToClose", nil, "|TInterface\\TUTORIALFRAME\\UI-TUTORIAL-FRAME:"..w..":"..h..":0:1:512:512:8:70:328:409|t " .. text)
 	end
 
 --> show & hide
@@ -2504,7 +2504,7 @@ local on_click_feedback = function (self)
 	local feedback_link_textbox = DF.feedback_link_textbox
 	
 	if (not feedback_link_textbox) then
-		local editbox = DF:CreateTextEntry (AddonFeedbackPanel, _, 275, 34)
+		local editbox = DF:CreateTextEntry (AddonFeedbackPanel, nil, 275, 34)
 		editbox:SetAutoFocus (false)
 		editbox:SetHook ("OnEditFocusGained", function() 
 			editbox.text = editbox.link
@@ -2574,7 +2574,7 @@ local on_click_feedback = function (self)
 	local feedback_link_textbox = DF.feedback_link_textbox
 	
 	if (not feedback_link_textbox) then
-		local editbox = DF:CreateTextEntry (AddonFeedbackPanel, _, 275, 34)
+		local editbox = DF:CreateTextEntry (AddonFeedbackPanel, nil, 275, 34)
 		editbox:SetAutoFocus (false)
 		editbox:SetHook ("OnEditFocusGained", function() 
 			editbox.text = editbox.link
@@ -2625,7 +2625,7 @@ local on_click_addon = function (self)
 	local addon_link_textbox = DF.addon_link_textbox
 	
 	if (not addon_link_textbox) then
-		local editbox = DF:CreateTextEntry (AddonFeedbackPanel, _, 128, 64)
+		local editbox = DF:CreateTextEntry (AddonFeedbackPanel, nil, 128, 64)
 		editbox:SetAutoFocus (false)
 		editbox:SetHook ("OnEditFocusGained", function() 
 			editbox.text = editbox.link
@@ -3855,7 +3855,7 @@ DF.TabContainerFunctions.OnMouseDown = function (self, button)
 				end
 			else
 				--goes back to front page
-				DF.TabContainerFunctions.SelectIndex (self, _, 1)
+				DF.TabContainerFunctions.SelectIndex (self, nil, 1)
 			end
 		end
 	end
@@ -4564,10 +4564,10 @@ function DF:CreateKeybindBox (parent, name, data, callback, width, height, line_
 	end
 
 	--choose which spec to use
-	local spec1 = DF:CreateButton (new_keybind_frame, switch_spec, 160, 20, "Spec1 Placeholder Text", 1, _, _, "SpecButton1", _, 0, options_button_template, options_text_template)
-	local spec2 = DF:CreateButton (new_keybind_frame, switch_spec, 160, 20, "Spec2 Placeholder Text", 1, _, _, "SpecButton2", _, 0, options_button_template, options_text_template)
-	local spec3 = DF:CreateButton (new_keybind_frame, switch_spec, 160, 20, "Spec3 Placeholder Text", 1, _, _, "SpecButton3", _, 0, options_button_template, options_text_template)
-	local spec4 = DF:CreateButton (new_keybind_frame, switch_spec, 160, 20, "Spec4 Placeholder Text", 1, _, _, "SpecButton4", _, 0, options_button_template, options_text_template)
+	local spec1 = DF:CreateButton (new_keybind_frame, switch_spec, 160, 20, "Spec1 Placeholder Text", 1, nil, nil, "SpecButton1", nil, 0, options_button_template, options_text_template)
+	local spec2 = DF:CreateButton (new_keybind_frame, switch_spec, 160, 20, "Spec2 Placeholder Text", 1, nil, nil, "SpecButton2", nil, 0, options_button_template, options_text_template)
+	local spec3 = DF:CreateButton (new_keybind_frame, switch_spec, 160, 20, "Spec3 Placeholder Text", 1, nil, nil, "SpecButton3", nil, 0, options_button_template, options_text_template)
+	local spec4 = DF:CreateButton (new_keybind_frame, switch_spec, 160, 20, "Spec4 Placeholder Text", 1, nil, nil, "SpecButton4", nil, 0, options_button_template, options_text_template)
 	
 	--format the button label and icon with the spec information
 	local className, class = UnitClass ("player")
@@ -4741,7 +4741,7 @@ function DF:CreateKeybindBox (parent, name, data, callback, width, height, line_
 	
 	local newTitle = DF:CreateLabel (new_keybind_frame, "Create a new Keybind:", 12, "silver")
 	newTitle:SetPoint ("topleft", new_keybind_frame, "topleft", 200, mainStartY)
-	local createNewKeybind = DF:CreateButton (new_keybind_frame, new_key_bind, 160, 20, "New Key Bind", 1, _, _, "NewKeybindButton", _, 0, options_button_template, options_text_template)
+	local createNewKeybind = DF:CreateButton (new_keybind_frame, new_key_bind, 160, 20, "New Key Bind", 1, nil, nil, "NewKeybindButton", nil, 0, options_button_template, options_text_template)
 	createNewKeybind:SetPoint ("topleft", newTitle, "bottomleft", 0, -10)
 	--createNewKeybind:SetIcon ([[Interface\Buttons\UI-GuildButton-PublicNote-Up]])
 
@@ -4826,11 +4826,11 @@ function DF:CreateKeybindBox (parent, name, data, callback, width, height, line_
 		tinsert (keybindScroll.Frames, f)
 		
 		f.Index = DF:CreateLabel (f, "1")
-		f.KeyBind = DF:CreateButton (f, set_key_bind, 100, 20, "", _, _, _, "SetNewKeybindButton", _, 0, options_button_template, options_text_template)
-		f.ActionDrop = DF:CreateDropDown (f, fill_action_dropdown, 0, 120, 20, "ActionDropdown", _, options_dropdown_template)
+		f.KeyBind = DF:CreateButton (f, set_key_bind, 100, 20, "", nil, nil, nil, "SetNewKeybindButton", nil, 0, options_button_template, options_text_template)
+		f.ActionDrop = DF:CreateDropDown (f, fill_action_dropdown, 0, 120, 20, "ActionDropdown", nil, options_dropdown_template)
 		f.ActionText = DF:CreateTextEntry (f, function()end, 660, 20, "TextBox", _, _, options_dropdown_template)
-		f.Copy = DF:CreateButton (f, copy_keybind, 20, 20, "", _, _, _, "CopyKeybindButton", _, 0, options_button_template, options_text_template)
-		f.Delete = DF:CreateButton (f, delete_keybind, 16, 20, "", _, _, _, "DeleteKeybindButton", _, 2, options_button_template, options_text_template)
+		f.Copy = DF:CreateButton (f, copy_keybind, 20, 20, "", nil, nil, nil, "CopyKeybindButton", nil, 0, options_button_template, options_text_template)
+		f.Delete = DF:CreateButton (f, delete_keybind, 16, 20, "", nil, nil, nil, "DeleteKeybindButton", nil, 2, options_button_template, options_text_template)
 		
 		f.Index:SetPoint ("left", f, "left", 10, 0)
 		f.KeyBind:SetPoint ("left", f, "left", 43, 0)

--- a/boot.lua
+++ b/boot.lua
@@ -768,7 +768,7 @@ do
 			function _detalhes:wipe_combat_after_failed_load()
 				_detalhes.tabela_historico = _detalhes.historico:NovoHistorico()
 				_detalhes.tabela_overall = _detalhes.combate:NovaTabela()
-				_detalhes.tabela_vigente = _detalhes.combate:NovaTabela (_, _detalhes.tabela_overall)
+				_detalhes.tabela_vigente = _detalhes.combate:NovaTabela (nil, _detalhes.tabela_overall)
 				_detalhes.tabela_pets = _detalhes.container_pets:NovoContainer()
 				_detalhes:UpdateContainerCombatentes()
 				

--- a/classes/class_custom.lua
+++ b/classes/class_custom.lua
@@ -238,11 +238,11 @@
 						end
 						
 						if (type (value) == "number") then
-							value = SelectedToKFunction (_, value)
+							value = SelectedToKFunction (nil, value)
 						end
 						ptotal = value
 					else
-						ptotal = SelectedToKFunction (_, _math_floor (actor.value))
+						ptotal = SelectedToKFunction (nil, _math_floor (actor.value))
 					end
 					
 					actor.report_value = ptotal .. " (" .. percent .. "%)"
@@ -293,7 +293,7 @@
 		if (source == "[all]") then
 			
 			for _, actor in _ipairs (combat_container) do 
-				local actortotal = func (_, actor, source, target, spellid, combat, instance_container)
+				local actortotal = func (nil, actor, source, target, spellid, combat, instance_container)
 				if (actortotal > 0) then
 					total = total + actortotal
 					amount = amount + 1
@@ -322,7 +322,7 @@
 						Details:Msg("error on class_custom 'func' is invalid, backtrace:", debugstack())
 						return
 					end
-					local actortotal = func (_, actor, source, target, spellid, combat, instance_container)
+					local actortotal = func (nil, actor, source, target, spellid, combat, instance_container)
 
 					if (actortotal > 0) then
 						total = total + actortotal
@@ -342,7 +342,7 @@
 			local pindex = combat [container_index]._NameIndexTable [_detalhes.playername]
 			if (pindex) then
 				local actor = combat [container_index]._ActorTable [pindex]
-				local actortotal = func (_, actor, source, target, spellid, combat, instance_container)
+				local actortotal = func (nil, actor, source, target, spellid, combat, instance_container)
 				
 				if (actortotal > 0) then
 					total = total + actortotal
@@ -360,7 +360,7 @@
 			local pindex = combat [container_index]._NameIndexTable [source]
 			if (pindex) then
 				local actor = combat [container_index]._ActorTable [pindex]
-				local actortotal = func (_, actor, source, target, spellid, combat, instance_container)
+				local actortotal = func (nil, actor, source, target, spellid, combat, instance_container)
 				
 				if (actortotal > 0) then
 					total = total + actortotal
@@ -538,13 +538,13 @@
 				return _detalhes:EndRefresh (instance, 0, combat, combat [1])
 			end
 			if (type (value) == "number") then
-				row.lineText4:SetText (SelectedToKFunction (_, value) .. bars_brackets[1] .. percent .. bars_brackets[2])
+				row.lineText4:SetText (SelectedToKFunction (nil, value) .. bars_brackets[1] .. percent .. bars_brackets[2])
 				
 			else
 				row.lineText4:SetText (value .. bars_brackets[1] .. percent .. bars_brackets[2])
 			end
 		else
-			local formated_value = SelectedToKFunction (_, self.value)
+			local formated_value = SelectedToKFunction (nil, self.value)
 			local rightText = formated_value .. bars_brackets[1] .. percent .. bars_brackets[2]
 			if (UsingCustomRightText) then
 				row.lineText4:SetText (_string_replace (instance.row_info.textR_custom_text, formated_value, "", percent, self, combat, instance, rightText))
@@ -979,7 +979,7 @@
 			local func = atributo_custom [attribute .. "Tooltip"]
 			
 			--> build the tooltip
-			func (_, actor, custom_object.target, custom_object.spellid, instance.showing, instance)
+			func (nil, actor, custom_object.target, custom_object.spellid, instance.showing, instance)
 		end
 		
 		return true
@@ -2094,7 +2094,7 @@
 				local DamageOnStar = RaidTargets [128]
 				if (DamageOnStar) then
 				    --RAID_TARGET_8 is the built-in localized word for 'Skull'.
-				    GameCooltip:AddLine (RAID_TARGET_8 .. ":", format_func (_, DamageOnStar))
+				    GameCooltip:AddLine (RAID_TARGET_8 .. ":", format_func (nil, DamageOnStar))
 				    GameCooltip:AddIcon ("Interface\\TARGETINGFRAME\\UI-RaidTargetingIcon_8", 1, 1, _detalhes.tooltip.line_height, _detalhes.tooltip.line_height)
 				    Details:AddTooltipBackgroundStatusbar()
 				end
@@ -2182,49 +2182,49 @@
 
 				local DamageOnStar = RaidTargets [1]
 				if (DamageOnStar) then
-				    GameCooltip:AddLine (RAID_TARGET_1 .. ":", format_func (_, DamageOnStar))
+				    GameCooltip:AddLine (RAID_TARGET_1 .. ":", format_func (nil, DamageOnStar))
 				    GameCooltip:AddIcon ("Interface\\TARGETINGFRAME\\UI-RaidTargetingIcon_1", 1, 1, _detalhes.tooltip.line_height, _detalhes.tooltip.line_height)
 				    Details:AddTooltipBackgroundStatusbar()
 				end
 
 				local DamageOnCircle = RaidTargets [2]
 				if (DamageOnCircle) then
-				    GameCooltip:AddLine (RAID_TARGET_2 .. ":", format_func (_, DamageOnCircle))
+				    GameCooltip:AddLine (RAID_TARGET_2 .. ":", format_func (nil, DamageOnCircle))
 				    GameCooltip:AddIcon ("Interface\\TARGETINGFRAME\\UI-RaidTargetingIcon_2", 1, 1, _detalhes.tooltip.line_height, _detalhes.tooltip.line_height)
 				    Details:AddTooltipBackgroundStatusbar()
 				end
 
 				local DamageOnDiamond = RaidTargets [4]
 				if (DamageOnDiamond) then
-				    GameCooltip:AddLine (RAID_TARGET_3 .. ":", format_func (_, DamageOnDiamond))
+				    GameCooltip:AddLine (RAID_TARGET_3 .. ":", format_func (nil, DamageOnDiamond))
 				    GameCooltip:AddIcon ("Interface\\TARGETINGFRAME\\UI-RaidTargetingIcon_3", 1, 1, _detalhes.tooltip.line_height, _detalhes.tooltip.line_height)
 				    Details:AddTooltipBackgroundStatusbar()
 				end
 
 				local DamageOnTriangle = RaidTargets [8]
 				if (DamageOnTriangle) then
-				    GameCooltip:AddLine (RAID_TARGET_4 .. ":", format_func (_, DamageOnTriangle))
+				    GameCooltip:AddLine (RAID_TARGET_4 .. ":", format_func (nil, DamageOnTriangle))
 				    GameCooltip:AddIcon ("Interface\\TARGETINGFRAME\\UI-RaidTargetingIcon_4", 1, 1, _detalhes.tooltip.line_height, _detalhes.tooltip.line_height)
 				    Details:AddTooltipBackgroundStatusbar()
 				end
 
 				local DamageOnMoon = RaidTargets [16]
 				if (DamageOnMoon) then
-				    GameCooltip:AddLine (RAID_TARGET_5 .. ":", format_func (_, DamageOnMoon))
+				    GameCooltip:AddLine (RAID_TARGET_5 .. ":", format_func (nil, DamageOnMoon))
 				    GameCooltip:AddIcon ("Interface\\TARGETINGFRAME\\UI-RaidTargetingIcon_5", 1, 1, _detalhes.tooltip.line_height, _detalhes.tooltip.line_height)
 				    Details:AddTooltipBackgroundStatusbar()
 				end
 
 				local DamageOnSquare = RaidTargets [32]
 				if (DamageOnSquare) then
-				    GameCooltip:AddLine (RAID_TARGET_6 .. ":", format_func (_, DamageOnSquare))
+				    GameCooltip:AddLine (RAID_TARGET_6 .. ":", format_func (nil, DamageOnSquare))
 				    GameCooltip:AddIcon ("Interface\\TARGETINGFRAME\\UI-RaidTargetingIcon_6", 1, 1, _detalhes.tooltip.line_height, _detalhes.tooltip.line_height)
 				    Details:AddTooltipBackgroundStatusbar()
 				end
 
 				local DamageOnCross = RaidTargets [64]
 				if (DamageOnCross) then
-				    GameCooltip:AddLine (RAID_TARGET_7 .. ":", format_func (_, DamageOnCross))
+				    GameCooltip:AddLine (RAID_TARGET_7 .. ":", format_func (nil, DamageOnCross))
 				    GameCooltip:AddIcon ("Interface\\TARGETINGFRAME\\UI-RaidTargetingIcon_7", 1, 1, _detalhes.tooltip.line_height, _detalhes.tooltip.line_height)
 				    Details:AddTooltipBackgroundStatusbar()
 				end
@@ -2358,7 +2358,7 @@
 				    if (total > 1) then
 					local spellName, _, spellIcon = Details.GetSpellInfo (spellID)
 					
-					GameCooltip:AddLine (spellName, format_func (_, total))
+					GameCooltip:AddLine (spellName, format_func (nil, total))
 					Details:AddTooltipBackgroundStatusbar()
 					GameCooltip:AddIcon (spellIcon, 1, 1, _detalhes.tooltip.line_height, _detalhes.tooltip.line_height)
 				    end
@@ -2379,12 +2379,12 @@
 
 				--build the string
 				local ToK = Details:GetCurrentToKFunction()
-				local s = ToK (_, value / OverallCombatTime)
+				local s = ToK (nil, value / OverallCombatTime)
 				
 				if (instance.row_info.textR_show_data[3]) then
-				    s = ToK (_, value) .. " (" .. s .. ", "
+				    s = ToK (nil, value) .. " (" .. s .. ", "
 				else
-				    s = ToK (_, value) .. " (" .. s
+				    s = ToK (nil, value) .. " (" .. s
 				end
 
 				return s
@@ -2476,7 +2476,7 @@
 				    end
 				end
 
-				GameCooltip:AddLine (actor:Name(), format_func (_, actor.totalabsorbed))
+				GameCooltip:AddLine (actor:Name(), format_func (nil, actor.totalabsorbed))
 				Details:AddTooltipBackgroundStatusbar()
 
 				for petIndex, petName in ipairs (actor.pets) do
@@ -2484,7 +2484,7 @@
 				    if (pet) then
 					totalAbsorb = totalAbsorb + pet.totalabsorbed
 					
-					GameCooltip:AddLine (petName, format_func (_, pet.totalabsorbed))
+					GameCooltip:AddLine (petName, format_func (nil, pet.totalabsorbed))
 					Details:AddTooltipBackgroundStatusbar()        
 					
 				    end

--- a/classes/class_damage.lua
+++ b/classes/class_damage.lua
@@ -947,9 +947,9 @@
 		local bars_brackets = instancia:GetBarBracket()
 		--
 		if (instancia.use_multi_fontstrings) then
-			Details:SetTextsOnLine(thisLine, "", (spell_damage and SelectedToKFunction (_, spell_damage) or ""), porcentagem)
+			Details:SetTextsOnLine(thisLine, "", (spell_damage and SelectedToKFunction (nil, spell_damage) or ""), porcentagem)
 		else
-			thisLine.lineText4:SetText ((spell_damage and SelectedToKFunction (_, spell_damage) or "") .. bars_brackets[1] .. porcentagem .. bars_brackets[2])
+			thisLine.lineText4:SetText ((spell_damage and SelectedToKFunction (nil, spell_damage) or "") .. bars_brackets[1] .. porcentagem .. bars_brackets[2])
 		end
 
 		thisLine.lineText1:SetTextColor(1, 1, 1, 1)
@@ -1048,7 +1048,7 @@
 				for i = 1, math.min (min, #damage_taken_table) do 
 					local t = damage_taken_table [i]
 				
-					GameCooltip:AddLine (Details:GetOnlyName (t[1]), FormatTooltipNumber (_, t[2]) .. " (" .. _cstr ("%.1f", t[2] / total * 100) .. "%)")
+					GameCooltip:AddLine (Details:GetOnlyName (t[1]), FormatTooltipNumber (nil, t[2]) .. " (" .. _cstr ("%.1f", t[2] / total * 100) .. "%)")
 					local classe = t[3]
 					if (not classe) then
 						classe = "UNKNOW"
@@ -1343,9 +1343,9 @@
 				local actor_table = {Details:GetOnlyName (void_table[1])}
 				local m, s = _math_floor (void_table[3].uptime / 60), _math_floor (void_table[3].uptime % 60)
 				if (m > 0) then
-					actor_table [2] = FormatTooltipNumber (_, void_table[3].damage) .. " (" .. m .. "m " .. s .. "s" .. ")"
+					actor_table [2] = FormatTooltipNumber (nil, void_table[3].damage) .. " (" .. m .. "m " .. s .. "s" .. ")"
 				else
-					actor_table [2] = FormatTooltipNumber (_, void_table[3].damage) .. " (" .. s .. "s" .. ")"
+					actor_table [2] = FormatTooltipNumber (nil, void_table[3].damage) .. " (" .. s .. "s" .. ")"
 				end
 				t [#t+1] = actor_table
 			end
@@ -1376,7 +1376,7 @@
 	
 	function Details:ToolTipVoidZones (instancia, actor, barra, keydown)
 		
-		local damage_actor = instancia.showing[1]:PegarCombatente (_, actor.damage_twin)
+		local damage_actor = instancia.showing[1]:PegarCombatente (nil, actor.damage_twin)
 		local habilidade
 		local alvos
 		
@@ -1457,9 +1457,9 @@
 
 			local minutos, segundos = _math_floor (debuff_table.uptime / 60), _math_floor (debuff_table.uptime % 60)
 			if (minutos > 0) then
-				GameCooltip:AddLine (Details:GetOnlyName (t[1]), FormatTooltipNumber (_, debuff_table.damage) .. " (" .. minutos .. "m " .. segundos .. "s" .. ")")
+				GameCooltip:AddLine (Details:GetOnlyName (t[1]), FormatTooltipNumber (nil, debuff_table.damage) .. " (" .. minutos .. "m " .. segundos .. "s" .. ")")
 			else
-				GameCooltip:AddLine (Details:GetOnlyName (t[1]), FormatTooltipNumber (_, debuff_table.damage) .. " (" .. segundos .. "s" .. ")")
+				GameCooltip:AddLine (Details:GetOnlyName (t[1]), FormatTooltipNumber (nil, debuff_table.damage) .. " (" .. segundos .. "s" .. ")")
 			end
 			
 			local classe = Details:GetClass (t[1])
@@ -1521,8 +1521,8 @@
 		local combat_time = instancia.showing:GetCombatTime()
 		local dps = _math_floor (self.damage / combat_time)
 		
-		local formated_damage = SelectedToKFunction (_, self.damage)
-		local formated_dps = SelectedToKFunction (_, dps)
+		local formated_damage = SelectedToKFunction (nil, self.damage)
+		local formated_dps = SelectedToKFunction (nil, dps)
 		
 		local porcentagem
 		
@@ -2461,8 +2461,8 @@ function atributo_damage:RefreshLine (instance, lineContainer, whichRowLine, ran
 	--right text
 	if (sub_atributo == 1) then --damage done
 		dps = _math_floor (dps)
-		local formated_damage = SelectedToKFunction (_, damage_total)
-		local formated_dps = SelectedToKFunction (_, dps)
+		local formated_damage = SelectedToKFunction (nil, damage_total)
+		local formated_dps = SelectedToKFunction (nil, dps)
 		thisLine.ps_text = formated_dps
 
 		if (not bars_show_data [1]) then
@@ -2496,8 +2496,8 @@ function atributo_damage:RefreshLine (instance, lineContainer, whichRowLine, ran
 		local raw_dps = dps
 		dps = _math_floor (dps)
 		
-		local formated_damage = SelectedToKFunction (_, damage_total)
-		local formated_dps = SelectedToKFunction (_, dps)
+		local formated_damage = SelectedToKFunction (nil, damage_total)
+		local formated_dps = SelectedToKFunction (nil, dps)
 		thisLine.ps_text = formated_dps
 	
 		local diff_from_topdps
@@ -2526,7 +2526,7 @@ function atributo_damage:RefreshLine (instance, lineContainer, whichRowLine, ran
 			if (not bars_show_data [2]) then
 				color_percent = ""
 			else
-				color_percent = bars_brackets[1] .. "|cFFFF4444-|r|cFF" .. color_percent .. SelectedToKFunction (_, _math_floor (diff_from_topdps)) .. "|r" .. bars_brackets[2]
+				color_percent = bars_brackets[1] .. "|cFFFF4444-|r|cFF" .. color_percent .. SelectedToKFunction (nil, _math_floor (diff_from_topdps)) .. "|r" .. bars_brackets[2]
 			end
 			
 			rightText = formated_dps .. color_percent
@@ -2559,8 +2559,8 @@ function atributo_damage:RefreshLine (instance, lineContainer, whichRowLine, ran
 
 		local dtps = self.damage_taken / combat_time
 	
-		local formated_damage_taken = SelectedToKFunction (_, self.damage_taken)
-		local formated_dtps = SelectedToKFunction (_, dtps)
+		local formated_damage_taken = SelectedToKFunction (nil, self.damage_taken)
+		local formated_dtps = SelectedToKFunction (nil, dtps)
 		thisLine.ps_text = formated_dtps
 
 		if (not bars_show_data [1]) then
@@ -2590,7 +2590,7 @@ function atributo_damage:RefreshLine (instance, lineContainer, whichRowLine, ran
 		
 	elseif (sub_atributo == 4) then --friendly fire
 	
-		local formated_friendly_fire = SelectedToKFunction (_, self.friendlyfire_total)
+		local formated_friendly_fire = SelectedToKFunction (nil, self.friendlyfire_total)
 
 		if (not bars_show_data [1]) then
 			formated_friendly_fire = ""
@@ -2617,8 +2617,8 @@ function atributo_damage:RefreshLine (instance, lineContainer, whichRowLine, ran
 	
 		local dtps = self.damage_taken / combat_time
 	
-		local formated_damage_taken = SelectedToKFunction (_, self.damage_taken)
-		local formated_dtps = SelectedToKFunction (_, dtps)
+		local formated_damage_taken = SelectedToKFunction (nil, self.damage_taken)
+		local formated_dtps = SelectedToKFunction (nil, dtps)
 		thisLine.ps_text = formated_dtps
 
 		if (not bars_show_data [1]) then
@@ -3072,9 +3072,9 @@ function atributo_damage:ToolTip_DamageDone (instancia, numero, barra, keydown)
 					end
 					
 					if (instancia.sub_atributo == 1 or instancia.sub_atributo == 6) then
-						GameCooltip:AddLine (nome_magia, FormatTooltipNumber (_, totalDamage) .." (".._cstr("%.1f", totalDamage/ActorDamage*100).."%)")
+						GameCooltip:AddLine (nome_magia, FormatTooltipNumber (nil, totalDamage) .." (".._cstr("%.1f", totalDamage/ActorDamage*100).."%)")
 					else
-						GameCooltip:AddLine (nome_magia, FormatTooltipNumber (_, _math_floor (totalDPS)) .." (".._cstr("%.1f", totalDamage/ActorDamage*100).."%)")
+						GameCooltip:AddLine (nome_magia, FormatTooltipNumber (nil, _math_floor (totalDPS)) .." (".._cstr("%.1f", totalDamage/ActorDamage*100).."%)")
 					end
 					
 					GameCooltip:AddIcon (icone_magia, nil, nil, icon_size.W + 4, icon_size.H + 4, icon_border.L, icon_border.R, icon_border.T, icon_border.B)
@@ -3098,7 +3098,7 @@ function atributo_damage:ToolTip_DamageDone (instancia, numero, barra, keydown)
 						local spellName, _, spellIcon = _GetSpellInfo(spellId)
 
 						if (spellName) then
-							GameCooltip:AddLine (spellName, FormatTooltipNumber (_, damageDone) .. " (" .. _math_floor (damageDone / self.total * 100) .. "%)")
+							GameCooltip:AddLine (spellName, FormatTooltipNumber (nil, damageDone) .. " (" .. _math_floor (damageDone / self.total * 100) .. "%)")
 							Details:AddTooltipBackgroundStatusbar (false, damageDone / self.total * 100)
 							GameCooltip:AddIcon (spellIcon, 1, 1, icon_size.W, icon_size.H, 0.1, 0.9, 0.1, 0.9)
 						end
@@ -3133,7 +3133,7 @@ function atributo_damage:ToolTip_DamageDone (instancia, numero, barra, keydown)
 
 				for i = 1, _math_min (max_targets, #ActorTargetsSortTable) do
 					local este_inimigo = ActorTargetsSortTable [i]
-					GameCooltip:AddLine (este_inimigo[1], FormatTooltipNumber (_, este_inimigo[2]) .." (".._cstr("%.1f", este_inimigo[2]/ActorDamageWithPet*100).."%)")
+					GameCooltip:AddLine (este_inimigo[1], FormatTooltipNumber (nil, este_inimigo[2]) .." (".._cstr("%.1f", este_inimigo[2]/ActorDamageWithPet*100).."%)")
 					GameCooltip:AddIcon ([[Interface\PetBattles\PetBattle-StatIcons]], nil, nil, icon_size.W, icon_size.H, 0, 0.5, 0, 0.5, {.7, .7, .7, 1}, nil, true)
 					Details:AddTooltipBackgroundStatusbar (false, este_inimigo[2] / topEnemy * 100)
 				end
@@ -3227,9 +3227,9 @@ function atributo_damage:ToolTip_DamageDone (instancia, numero, barra, keydown)
 			
 				local n = _table [1]:gsub (("%s%<.*"), "")
 				if (instancia.sub_atributo == 1) then
-					GameCooltip:AddLine (n, FormatTooltipNumber (_, _table [2]) .. " (" .. _math_floor (_table [2]/self.total*100) .. "%)")
+					GameCooltip:AddLine (n, FormatTooltipNumber (nil, _table [2]) .. " (" .. _math_floor (_table [2]/self.total*100) .. "%)")
 				else
-					GameCooltip:AddLine (n, FormatTooltipNumber (_,  _math_floor (_table [3])) .. " (" .. _math_floor (_table [2]/self.total*100) .. "%)")
+					GameCooltip:AddLine (n, FormatTooltipNumber (nil,  _math_floor (_table [3])) .. " (" .. _math_floor (_table [2]/self.total*100) .. "%)")
 				end
 				
 				Details:AddTooltipBackgroundStatusbar (false, _table [2] / topPet * 100)
@@ -3281,7 +3281,7 @@ function atributo_damage:ToolTip_DamageDone (instancia, numero, barra, keydown)
 				
 				for i = 1, #playerPhases do
 					--[1] Phase Number [2] Amount Done [3] Rank [4] Percent
-					GameCooltip:AddLine ("|cFFF0F0F0Phase|r " .. playerPhases [i][1], FormatTooltipNumber (_, playerPhases [i][2]) .. " (|cFFFFFF00#" .. playerPhases [i][3] ..  "|r, " .. _cstr ("%.1f", playerPhases [i][4]) .. "%)")
+					GameCooltip:AddLine ("|cFFF0F0F0Phase|r " .. playerPhases [i][1], FormatTooltipNumber (nil, playerPhases [i][2]) .. " (|cFFFFFF00#" .. playerPhases [i][3] ..  "|r, " .. _cstr ("%.1f", playerPhases [i][4]) .. "%)")
 					GameCooltip:AddIcon ([[Interface\Garrison\orderhall-missions-mechanic9]], 1, 1, 14, 14, 11/64, 53/64, 11/64, 53/64)
 					Details:AddTooltipBackgroundStatusbar()
 				end
@@ -3421,7 +3421,7 @@ function atributo_damage:ToolTip_Enemies (instancia, numero, barra, keydown)
 		local total = tooltip_temp_table [o][2]
 		local player_name = Details:GetOnlyName (player:name())
 	
-		GameCooltip:AddLine (player_name .. " ", FormatTooltipNumber (_, total) .." (" .. _cstr ("%.1f", (total / damage_taken) * 100) .. "%)")
+		GameCooltip:AddLine (player_name .. " ", FormatTooltipNumber (nil, total) .." (" .. _cstr ("%.1f", (total / damage_taken) * 100) .. "%)")
 		
 		local classe = player:class()
 		if (not classe) then
@@ -3448,14 +3448,14 @@ function atributo_damage:ToolTip_Enemies (instancia, numero, barra, keydown)
 	
 	--> damage done and heal
 	GameCooltip:AddLine (" ")
-	GameCooltip:AddLine (Loc ["STRING_ATTRIBUTE_DAMAGE_ENEMIES_DONE"], FormatTooltipNumber (_, _math_floor (self.total)))
+	GameCooltip:AddLine (Loc ["STRING_ATTRIBUTE_DAMAGE_ENEMIES_DONE"], FormatTooltipNumber (nil, _math_floor (self.total)))
 	local half = 0.00048828125
 	GameCooltip:AddIcon (instancia:GetSkinTexture(), 1, 1, 14, 14, 0.005859375 + half, 0.025390625 - half, 0.3623046875, 0.3818359375)
 	GameCooltip:AddStatusBar (0, 1, r, g, b, 1, false, enemies_background)
 	
 	local heal_actor = instancia.showing (2, self.nome)
 	if (heal_actor) then
-		GameCooltip:AddLine (Loc ["STRING_ATTRIBUTE_HEAL_ENEMY"], FormatTooltipNumber (_, _math_floor (heal_actor.heal_enemy_amt)))
+		GameCooltip:AddLine (Loc ["STRING_ATTRIBUTE_HEAL_ENEMY"], FormatTooltipNumber (nil, _math_floor (heal_actor.heal_enemy_amt)))
 	else
 		GameCooltip:AddLine (Loc ["STRING_ATTRIBUTE_HEAL_ENEMY"], 0)
 	end
@@ -3599,7 +3599,7 @@ function atributo_damage:ToolTip_DamageTaken (instancia, numero, barra, keydown)
 			
 			for _, spell in _ipairs (all_spells) do
 				local spellname, _, spellicon = _GetSpellInfo (spell [1])
-				GameCooltip:AddLine (spellname .. " (|cFFFFFF00" .. spell [3] .. "|r)", FormatTooltipNumber (_, spell [2]).." (" .. _cstr ("%.1f", (spell [2] / damage_taken) * 100).."%)")
+				GameCooltip:AddLine (spellname .. " (|cFFFFFF00" .. spell [3] .. "|r)", FormatTooltipNumber (nil, spell [2]).." (" .. _cstr ("%.1f", (spell [2] / damage_taken) * 100).."%)")
 				GameCooltip:AddIcon (spellicon, 1, 1, icon_size.W, icon_size.H, icon_border.L, icon_border.R, icon_border.T, icon_border.B)
 				Details:AddTooltipBackgroundStatusbar()
 			end
@@ -3607,9 +3607,9 @@ function atributo_damage:ToolTip_DamageTaken (instancia, numero, barra, keydown)
 		else
 			local aggressorName = Details:GetOnlyName (meus_agressores[i][1])
 			if (ismaximized and meus_agressores[i][1]:find (Details.playername)) then
-				GameCooltip:AddLine (aggressorName, FormatTooltipNumber (_, meus_agressores[i][2]).." (".._cstr("%.1f", (meus_agressores[i][2]/damage_taken) * 100).."%)", nil, "yellow")
+				GameCooltip:AddLine (aggressorName, FormatTooltipNumber (nil, meus_agressores[i][2]).." (".._cstr("%.1f", (meus_agressores[i][2]/damage_taken) * 100).."%)", nil, "yellow")
 			else
-				GameCooltip:AddLine (aggressorName, FormatTooltipNumber (_, meus_agressores[i][2]).." (".._cstr("%.1f", (meus_agressores[i][2]/damage_taken) * 100).."%)")
+				GameCooltip:AddLine (aggressorName, FormatTooltipNumber (nil, meus_agressores[i][2]).." (".._cstr("%.1f", (meus_agressores[i][2]/damage_taken) * 100).."%)")
 			end
 			local classe = meus_agressores[i][3]
 			
@@ -3629,14 +3629,14 @@ function atributo_damage:ToolTip_DamageTaken (instancia, numero, barra, keydown)
 	if (instancia.sub_atributo == 6) then
 	
 		GameCooltip:AddLine (" ")
-		GameCooltip:AddLine (Loc ["STRING_ATTRIBUTE_DAMAGE_DONE"], FormatTooltipNumber (_, _math_floor (self.total)))
+		GameCooltip:AddLine (Loc ["STRING_ATTRIBUTE_DAMAGE_DONE"], FormatTooltipNumber (nil, _math_floor (self.total)))
 		local half = 0.00048828125
 		GameCooltip:AddIcon (instancia:GetSkinTexture(), 1, 1, icon_size.W, icon_size.H, 0.005859375 + half, 0.025390625 - half, 0.3623046875, 0.3818359375)
 		Details:AddTooltipBackgroundStatusbar()
 		
 		local heal_actor = instancia.showing (2, self.nome)
 		if (heal_actor) then
-			GameCooltip:AddLine (Loc ["STRING_ATTRIBUTE_HEAL_DONE"], FormatTooltipNumber (_, _math_floor (heal_actor.heal_enemy_amt)))
+			GameCooltip:AddLine (Loc ["STRING_ATTRIBUTE_HEAL_DONE"], FormatTooltipNumber (nil, _math_floor (heal_actor.heal_enemy_amt)))
 		else
 			GameCooltip:AddLine (Loc ["STRING_ATTRIBUTE_HEAL_DONE"], 0)
 		end
@@ -3707,7 +3707,7 @@ function atributo_damage:ToolTip_FriendlyFire (instancia, numero, barra, keydown
 			classe = "UNKNOW"
 		end
 
-		GameCooltip:AddLine (Details:GetOnlyName (DamagedPlayers[i][1]), FormatTooltipNumber (_, DamagedPlayers[i][2]).." (".._cstr("%.1f", DamagedPlayers[i][2]/FriendlyFireTotal*100).."%)")
+		GameCooltip:AddLine (Details:GetOnlyName (DamagedPlayers[i][1]), FormatTooltipNumber (nil, DamagedPlayers[i][2]).." (".._cstr("%.1f", DamagedPlayers[i][2]/FriendlyFireTotal*100).."%)")
 		GameCooltip:AddIcon ("Interface\\AddOns\\Details\\images\\espadas", nil, nil, lineHeight, lineHeight)
 		Details:AddTooltipBackgroundStatusbar()
 		
@@ -3751,7 +3751,7 @@ function atributo_damage:ToolTip_FriendlyFire (instancia, numero, barra, keydown
 	
 	for i = 1, _math_min (max_abilities2, #SpellsInOrder) do
 		local nome, _, icone = _GetSpellInfo (SpellsInOrder[i][1])
-		GameCooltip:AddLine (nome, FormatTooltipNumber (_, SpellsInOrder[i][2]).." (".._cstr("%.1f", SpellsInOrder[i][2]/FriendlyFireTotal*100).."%)")
+		GameCooltip:AddLine (nome, FormatTooltipNumber (nil, SpellsInOrder[i][2]).." (".._cstr("%.1f", SpellsInOrder[i][2]/FriendlyFireTotal*100).."%)")
 		GameCooltip:AddIcon (icone, nil, nil, icon_size.W, icon_size.H, icon_border.L, icon_border.R, icon_border.T, icon_border.B)
 		Details:AddTooltipBackgroundStatusbar()
 	end	
@@ -3982,8 +3982,8 @@ function atributo_damage:MontaInfoDamageTaken()
 			texCoords = Details.class_coords ["UNKNOW"]
 		end
 		
-		local formated_value = SelectedToKFunction (_, _math_floor (tabela[2]))
-		self:UpdadeInfoBar (barra, index, tabela[1], tabela[1], tabela[2], formated_value, max_, tabela[3], "Interface\\AddOns\\Details\\images\\classes_small_alpha", true, texCoords, nil, tabela[4])
+		local formated_value = SelectedToKFunction (nil, _math_floor (tabela[2]))
+		self:UpdadeInfoBar (barra, index, tabela[1], tabela[1], tabela[2], formated_value, maxnil, tabela[3], "Interface\\AddOns\\Details\\images\\classes_small_alpha", true, texCoords, nil, tabela[4])
 	end
 	
 end
@@ -4177,7 +4177,7 @@ function atributo_damage:MontaInfoDamageDone()
 		if (not barra) then
 			barra = gump:CriaNovaBarraInfo1 (instancia, 1)
 		end
-		self:UpdadeInfoBar (barra, "", -51, "Auras", max_, false, max_, 100, [[Interface\BUTTONS\UI-GroupLoot-DE-Up]], true, nil, nil)
+		self:UpdadeInfoBar (barra, "", -51, "Auras", maxnil, false, maxnil, 100, [[Interface\BUTTONS\UI-GroupLoot-DE-Up]], true, nil, nil)
 		barra.textura:SetStatusBarColor (Details.gump:ParseColors ("purple"))
 	end
 	
@@ -4196,11 +4196,11 @@ function atributo_damage:MontaInfoDamageDone()
 		local name = tabela[4]
 		
 		if (info.sub_atributo == 2) then
-			local formated_value = SelectedToKFunction (_, _math_floor (tabela[2]/meu_tempo))
-			self:UpdadeInfoBar (barra, index, tabela[1], name, tabela[2], formated_value, max_, tabela[3], tabela[5], true, nil, tabela [7])
+			local formated_value = SelectedToKFunction (nil, _math_floor (tabela[2]/meu_tempo))
+			self:UpdadeInfoBar (barra, index, tabela[1], name, tabela[2], formated_value, maxnil, tabela[3], tabela[5], true, nil, tabela [7])
 		else
-			local formated_value = SelectedToKFunction (_, _math_floor (tabela[2]))
-			self:UpdadeInfoBar (barra, index, tabela[1], name, tabela[2], formated_value, max_, tabela[3], tabela[5], true, nil, tabela [7])
+			local formated_value = SelectedToKFunction (nil, _math_floor (tabela[2]))
+			self:UpdadeInfoBar (barra, index, tabela[1], name, tabela[2], formated_value, maxnil, tabela[3], tabela[5], true, nil, tabela [7])
 		end
 		
 		self:FocusLock (barra, tabela[1])
@@ -4348,7 +4348,7 @@ function atributo_damage:MontaInfoDamageDone()
 			if (info.sub_atributo == 2) then
 				barra.lineText4:SetText (Details:comma_value ( _math_floor (tabela[2]/meu_tempo)) .. " (" .. _cstr ("%.1f", tabela[3]) .. "%)")
 			else
-				barra.lineText4:SetText (SelectedToKFunction (_, tabela[2]) .." (" .. _cstr ("%.1f", tabela[3]) .. "%)")
+				barra.lineText4:SetText (SelectedToKFunction (nil, tabela[2]) .." (" .. _cstr ("%.1f", tabela[3]) .. "%)")
 			end
 			
 			if (barra.mouse_over) then --> atualizar o tooltip
@@ -4945,7 +4945,7 @@ end
 
 function atributo_damage:MontaTooltipDamageTaken (thisLine, index)
 	
-	local aggressor = info.instancia.showing [1]:PegarCombatente (_, thisLine.nome_inimigo)
+	local aggressor = info.instancia.showing [1]:PegarCombatente (nil, thisLine.nome_inimigo)
 	local container = aggressor.spells._ActorTable
 	local habilidades = {}
 
@@ -5089,8 +5089,8 @@ function atributo_damage:MontaTooltipAlvos (thisLine, index, instancia)
 				--GameCooltip:AddDoubleLine (index..". |T"..tabela[3]..":0|t "..tabela[1], Details:comma_value ( _math_floor (tabela[2] / meu_tempo) ).." (".._cstr("%.1f", tabela[2]/total*100).."%)", 1, 1, 1, 1, 1, 1)
 				GameCooltip:AddLine (tabela[1], Details:comma_value ( _math_floor (tabela[2] / meu_tempo) ).." (".._cstr("%.1f", tabela[2]/total*100).."%)")
 			else
-				--GameCooltip:AddDoubleLine (index..". |T"..tabela[3]..":0|t " .. tabela[1], SelectedToKFunction (_, tabela[2]) .. " (".._cstr("%.1f", tabela[2]/total*100).."%)", 1, 1, 1, 1, 1, 1)
-				GameCooltip:AddLine (tabela[1], SelectedToKFunction (_, tabela[2]) .. " (".._cstr("%.1f", tabela[2]/total*100).."%)")
+				--GameCooltip:AddDoubleLine (index..". |T"..tabela[3]..":0|t " .. tabela[1], SelectedToKFunction (nil, tabela[2]) .. " (".._cstr("%.1f", tabela[2]/total*100).."%)", 1, 1, 1, 1, 1, 1)
+				GameCooltip:AddLine (tabela[1], SelectedToKFunction (nil, tabela[2]) .. " (".._cstr("%.1f", tabela[2]/total*100).."%)")
 			end
 
 			GameCooltip:AddIcon (tabela[3], nil, nil, icon_size.W + 4, icon_size.H + 4, icon_border.L, icon_border.R, icon_border.T, icon_border.B)
@@ -5649,9 +5649,9 @@ end
 			local player_name = player:name()
 		
 			if (player_name:find (Details.playername)) then
-				GameCooltip:AddLine (player_name .. ": ", FormatTooltipNumber (_, total) .. " (" .. _cstr ("%.1f", (total / damage_done) * 100) .. "%)", 2, "yellow")
+				GameCooltip:AddLine (player_name .. ": ", FormatTooltipNumber (nil, total) .. " (" .. _cstr ("%.1f", (total / damage_done) * 100) .. "%)", 2, "yellow")
 			else
-				GameCooltip:AddLine (player_name .. ": ", FormatTooltipNumber (_, total) .." (" .. _cstr ("%.1f", (total / damage_done) * 100) .. "%)", 2)
+				GameCooltip:AddLine (player_name .. ": ", FormatTooltipNumber (nil, total) .." (" .. _cstr ("%.1f", (total / damage_done) * 100) .. "%)", 2)
 			end
 			
 			local classe = player:class()

--- a/classes/class_heal.lua
+++ b/classes/class_heal.lua
@@ -646,8 +646,8 @@ function atributo_heal:RefreshLine(instancia, barras_container, whichRowLine, lu
 		if (sub_atributo == 1) then --> mostrando healing done
 		
 			hps = _math_floor (hps)
-			local formated_heal = SelectedToKFunction (_, healing_total)
-			local formated_hps = SelectedToKFunction (_, hps)
+			local formated_heal = SelectedToKFunction (nil, healing_total)
+			local formated_hps = SelectedToKFunction (nil, hps)
 			thisLine.ps_text = formated_hps
 		
 			if (not bars_show_data [1]) then
@@ -677,8 +677,8 @@ function atributo_heal:RefreshLine(instancia, barras_container, whichRowLine, lu
 		elseif (sub_atributo == 2) then --> mostrando hps
 		
 			hps = _math_floor (hps)
-			local formated_heal = SelectedToKFunction (_, healing_total)
-			local formated_hps = SelectedToKFunction (_, hps)
+			local formated_heal = SelectedToKFunction (nil, healing_total)
+			local formated_hps = SelectedToKFunction (nil, hps)
 			thisLine.ps_text = formated_hps
 			
 			if (not bars_show_data [1]) then
@@ -708,7 +708,7 @@ function atributo_heal:RefreshLine(instancia, barras_container, whichRowLine, lu
 			
 		elseif (sub_atributo == 3) then --> mostrando overall
 		
-			local formated_overheal = SelectedToKFunction (_, self.totalover)
+			local formated_overheal = SelectedToKFunction (nil, self.totalover)
 			
 			local percent = self.totalover / (self.totalover + self.total) * 100
 			local overheal_percent = _cstr ("%.1f", percent)
@@ -741,7 +741,7 @@ function atributo_heal:RefreshLine(instancia, barras_container, whichRowLine, lu
 			
 		elseif (sub_atributo == 4) then --> mostrando healing taken
 		
-			local formated_healtaken = SelectedToKFunction (_, self.healing_taken)
+			local formated_healtaken = SelectedToKFunction (nil, self.healing_taken)
 			
 			if (not bars_show_data [1]) then
 				formated_healtaken = ""
@@ -767,7 +767,7 @@ function atributo_heal:RefreshLine(instancia, barras_container, whichRowLine, lu
 		
 		elseif (sub_atributo == 5) then --> mostrando enemy heal
 		
-			local formated_enemyheal = SelectedToKFunction (_, self.heal_enemy_amt)
+			local formated_enemyheal = SelectedToKFunction (nil, self.heal_enemy_amt)
 		
 			if (not bars_show_data [1]) then
 				formated_enemyheal = ""
@@ -792,7 +792,7 @@ function atributo_heal:RefreshLine(instancia, barras_container, whichRowLine, lu
 			
 		elseif (sub_atributo == 6) then --> mostrando damage prevented
 		
-			local formated_absorbs = SelectedToKFunction (_, self.totalabsorb)
+			local formated_absorbs = SelectedToKFunction (nil, self.totalabsorb)
 		
 			if (not bars_show_data [1]) then
 				formated_absorbs = ""
@@ -817,7 +817,7 @@ function atributo_heal:RefreshLine(instancia, barras_container, whichRowLine, lu
 			
 		elseif (sub_atributo == 7) then --> mostrando cura negada
 			
-			local formated_absorbs = SelectedToKFunction (_, self.totaldenied)
+			local formated_absorbs = SelectedToKFunction (nil, self.totaldenied)
 		
 			if (not bars_show_data [1]) then
 				formated_absorbs = ""
@@ -950,7 +950,7 @@ function _detalhes:CloseShields (combat)
 	
 	for alvo_name, spellid_table in _pairs (escudos) do
 	
-		local tgt = container:PegarCombatente (_, alvo_name)
+		local tgt = container:PegarCombatente (nil, alvo_name)
 		if (tgt) then
 		
 			for spellid, owner_table in _pairs (spellid_table) do
@@ -959,7 +959,7 @@ function _detalhes:CloseShields (combat)
 				for owner, amount in _pairs (owner_table) do
 				
 					if (amount > 0) then
-						local obj = container:PegarCombatente (_, owner)
+						local obj = container:PegarCombatente (nil, owner)
 						if (obj) then
 							parser:heal ("SPELL_AURA_REMOVED", time, obj.serial, owner, obj.flag_original, tgt.serial, alvo_name, tgt.flag_original, nil, spellid, spellname, nil, 0, _math_ceil (amount), 0, 0, nil, true)
 						end
@@ -1074,7 +1074,7 @@ function atributo_heal:ToolTip_HealingDenied (instancia, numero, barra, keydown)
 
 			local spellName, _, spellIcon = _GetSpellInfo (spellObject.id)
 			
-			GameCooltip:AddLine (spellName .. ": ", FormatTooltipNumber (_, spellTotal) .. " (" .. _cstr ("%.1f", spellTotal / totalDenied) .."%)")
+			GameCooltip:AddLine (spellName .. ": ", FormatTooltipNumber (nil, spellTotal) .. " (" .. _cstr ("%.1f", spellTotal / totalDenied) .."%)")
 
 			GameCooltip:AddIcon (spellIcon, nil, nil, icon_size.W, icon_size.H, icon_border.L, icon_border.R, icon_border.T, icon_border.B)
 			_detalhes:AddTooltipBackgroundStatusbar()
@@ -1110,7 +1110,7 @@ function atributo_heal:ToolTip_HealingDenied (instancia, numero, barra, keydown)
 		
 			local playerName, amountDenied = unpack (playerSorted [i])
 			
-			GameCooltip:AddLine (playerName .. ": ", FormatTooltipNumber (_, amountDenied) .." (" .. _cstr ("%.1f", amountDenied / totalDenied * 100) .. "%)")
+			GameCooltip:AddLine (playerName .. ": ", FormatTooltipNumber (nil, amountDenied) .." (" .. _cstr ("%.1f", amountDenied / totalDenied * 100) .. "%)")
 			_detalhes:AddTooltipBackgroundStatusbar()
 			
 			local targetActor = container:PegarCombatente (nil, playerName) or instancia.showing [1]:PegarCombatente (nil, playerName)
@@ -1154,7 +1154,7 @@ function atributo_heal:ToolTip_HealingDenied (instancia, numero, barra, keydown)
 
 			local spellName, _, spellIcon = _GetSpellInfo (spellID)
 			
-			GameCooltip:AddLine (spellName .. ": ", FormatTooltipNumber (_, spellTotal) .. " (" .. _cstr ("%.1f", spellTotal / totalDenied) .."%)")
+			GameCooltip:AddLine (spellName .. ": ", FormatTooltipNumber (nil, spellTotal) .. " (" .. _cstr ("%.1f", spellTotal / totalDenied) .."%)")
 
 			GameCooltip:AddIcon (spellIcon, nil, nil, icon_size.W, icon_size.H, icon_border.L, icon_border.R, icon_border.T, icon_border.B)
 			_detalhes:AddTooltipBackgroundStatusbar()
@@ -1175,7 +1175,7 @@ function atributo_heal:ToolTip_HealingDenied (instancia, numero, barra, keydown)
 		for i = 1, #healersSorted do
 			local playerName, amountDenied = unpack (healersSorted [i])
 			
-			GameCooltip:AddLine (playerName .. ": ", FormatTooltipNumber (_, amountDenied) .." (" .. _cstr ("%.1f", amountDenied / totalDenied * 100) .. "%)")
+			GameCooltip:AddLine (playerName .. ": ", FormatTooltipNumber (nil, amountDenied) .." (" .. _cstr ("%.1f", amountDenied / totalDenied * 100) .. "%)")
 			_detalhes:AddTooltipBackgroundStatusbar()
 			
 			local targetActor = container:PegarCombatente (nil, playerName) or instancia.showing [1]:PegarCombatente (nil, playerName)
@@ -1251,7 +1251,7 @@ function atributo_heal:ToolTip_HealingTaken (instancia, numero, barra, keydown)
 	local lineHeight = _detalhes.tooltip.line_height
 
 	for i = 1, _math_min (max, #meus_curadores) do
-		GameCooltip:AddLine (_detalhes:GetOnlyName (meus_curadores[i][1]), FormatTooltipNumber (_, meus_curadores[i][2]).." (".._cstr ("%.1f", (meus_curadores[i][2]/total_curado) * 100).."%)")
+		GameCooltip:AddLine (_detalhes:GetOnlyName (meus_curadores[i][1]), FormatTooltipNumber (nil, meus_curadores[i][2]).." (".._cstr ("%.1f", (meus_curadores[i][2]/total_curado) * 100).."%)")
 		local classe = meus_curadores[i][3]
 		if (not classe) then
 			classe = "UNKNOW"
@@ -1401,10 +1401,10 @@ function atributo_heal:ToolTip_HealingDone (instancia, numero, barra, keydown)
 		
 		if (instancia.sub_atributo == 2) then --> hps
 		
-			local formatedTotal = FormatTooltipNumber (_,  _math_floor (ActorHealingTable[i][5]))
+			local formatedTotal = FormatTooltipNumber (nil,  _math_floor (ActorHealingTable[i][5]))
 			local antiHeal = ActorHealingTable[i][8]
 			if (antiHeal) then
-				formatedTotal = formatedTotal .. " [|cFFFF5500" .. FormatTooltipNumber (_, _math_floor (antiHeal)) .." " .. Loc ["STRING_DAMAGE"] .."|r] "
+				formatedTotal = formatedTotal .. " [|cFFFF5500" .. FormatTooltipNumber (nil, _math_floor (antiHeal)) .." " .. Loc ["STRING_DAMAGE"] .."|r] "
 			end
 			
 			GameCooltip:AddLine (spellName , formatedTotal .. " (".._cstr ("%.1f", ActorHealingTable[i][3]).."%)")
@@ -1412,20 +1412,20 @@ function atributo_heal:ToolTip_HealingDone (instancia, numero, barra, keydown)
 		elseif (instancia.sub_atributo == 3) then --> overheal
 			local overheal = ActorHealingTable[i][2]
 			local total = ActorHealingTable[i][6]
-			local formatedTotal = FormatTooltipNumber (_,  _math_floor (ActorHealingTable[i][2]))
+			local formatedTotal = FormatTooltipNumber (nil,  _math_floor (ActorHealingTable[i][2]))
 			
 			local antiHeal = ActorHealingTable[i][8]
 			if (antiHeal) then
-				formatedTotal = formatedTotal .. " [|cFFFF5500" .. FormatTooltipNumber (_, _math_floor (antiHeal)) .." " .. Loc ["STRING_DAMAGE"] .."|r] "
+				formatedTotal = formatedTotal .. " [|cFFFF5500" .. FormatTooltipNumber (nil, _math_floor (antiHeal)) .." " .. Loc ["STRING_DAMAGE"] .."|r] "
 			end
 			
 			GameCooltip:AddLine (spellName .." (|cFFFF3333" .. _math_floor ( (overheal / (overheal+total)) *100)  .. "%|r)", formatedTotal .. " (".._cstr ("%.1f", ActorHealingTable[i][3]).."%)")
 			
 		else
-			local formatedTotal = FormatTooltipNumber (_, ActorHealingTable[i][2])
+			local formatedTotal = FormatTooltipNumber (nil, ActorHealingTable[i][2])
 			local antiHeal = ActorHealingTable[i][8]
 			if (antiHeal) then
-				formatedTotal = formatedTotal .. " [|cFFFF5500" .. FormatTooltipNumber (_, _math_floor (antiHeal)) .." " .. Loc ["STRING_DAMAGE"] .."|r] "
+				formatedTotal = formatedTotal .. " [|cFFFF5500" .. FormatTooltipNumber (nil, _math_floor (antiHeal)) .." " .. Loc ["STRING_DAMAGE"] .."|r] "
 			end
 			GameCooltip:AddLine (spellName , formatedTotal .. " (" .. _cstr ("%.1f", ActorHealingTable[i][3]) .. "%)")
 			
@@ -1472,10 +1472,10 @@ function atributo_heal:ToolTip_HealingDone (instancia, numero, barra, keydown)
 			end
 			
 			if (ismaximized and ActorHealingTargets[i][1]:find (_detalhes.playername)) then
-				GameCooltip:AddLine (ActorHealingTargets[i][1], FormatTooltipNumber (_, ActorHealingTargets[i][2]) .." (".._cstr ("%.1f", ActorHealingTargets[i][3]).."%)", nil, "yellow")
+				GameCooltip:AddLine (ActorHealingTargets[i][1], FormatTooltipNumber (nil, ActorHealingTargets[i][2]) .." (".._cstr ("%.1f", ActorHealingTargets[i][3]).."%)", nil, "yellow")
 				GameCooltip:AddStatusBar (100, 1, .5, .5, .5, .7)
 			else
-				GameCooltip:AddLine (ActorHealingTargets[i][1], FormatTooltipNumber (_, ActorHealingTargets[i][2]) .." (".._cstr ("%.1f", ActorHealingTargets[i][3]).."%)")
+				GameCooltip:AddLine (ActorHealingTargets[i][1], FormatTooltipNumber (nil, ActorHealingTargets[i][2]) .." (".._cstr ("%.1f", ActorHealingTargets[i][3]).."%)")
 				_detalhes:AddTooltipBackgroundStatusbar (false, ActorHealingTargets[i][2] / topTarget * 100)
 			end
 			
@@ -1560,12 +1560,12 @@ function atributo_heal:ToolTip_HealingDone (instancia, numero, barra, keydown)
 			
 				local n = _table [1]:gsub (("%s%<.*"), "")
 				if (instancia.sub_atributo == 3) then --overheal
-					GameCooltip:AddLine (n .. " (|cFFFF3333" .. _math_floor ( (_table [2] / (_table [2] + _table [3])) * 100)  .. "%|r):", FormatTooltipNumber (_,  _math_floor (_table [2])) .. " (" .. _math_floor ( (_table [2] / (_table [2] + _table [3])) * 100) .. "%)")
+					GameCooltip:AddLine (n .. " (|cFFFF3333" .. _math_floor ( (_table [2] / (_table [2] + _table [3])) * 100)  .. "%|r):", FormatTooltipNumber (nil,  _math_floor (_table [2])) .. " (" .. _math_floor ( (_table [2] / (_table [2] + _table [3])) * 100) .. "%)")
 					
 				elseif (instancia.sub_atributo == 2) then --hps
-					GameCooltip:AddLine (n, FormatTooltipNumber (_,  _math_floor (_table [3])) .. " (" .. _math_floor (_table [2]/self.total*100) .. "%)")
+					GameCooltip:AddLine (n, FormatTooltipNumber (nil,  _math_floor (_table [3])) .. " (" .. _math_floor (_table [2]/self.total*100) .. "%)")
 				else
-					GameCooltip:AddLine (n, FormatTooltipNumber (_, _table [2]) .. " (" .. _math_floor (_table [2]/self.total*100) .. "%)")
+					GameCooltip:AddLine (n, FormatTooltipNumber (nil, _table [2]) .. " (" .. _math_floor (_table [2]/self.total*100) .. "%)")
 				end
 				_detalhes:AddTooltipBackgroundStatusbar()
 				GameCooltip:AddIcon ([[Interface\AddOns\Details\images\classes_small]], 1, 1, icon_size.W, icon_size.H, 0.25, 0.49609375, 0.75, 1)
@@ -1613,7 +1613,7 @@ function atributo_heal:ToolTip_HealingDone (instancia, numero, barra, keydown)
 					
 					for i = 1, #playerPhases do
 						--[1] Phase Number [2] Amount Done [3] Rank [4] Percent
-						GameCooltip:AddLine ("|cFFF0F0F0Phase|r " .. playerPhases [i][1], FormatTooltipNumber (_, playerPhases [i][2]) .. " (|cFFFFFF00#" .. playerPhases [i][3] ..  "|r, " .. _cstr ("%.1f", playerPhases [i][4]) .. "%)")
+						GameCooltip:AddLine ("|cFFF0F0F0Phase|r " .. playerPhases [i][1], FormatTooltipNumber (nil, playerPhases [i][2]) .. " (|cFFFFFF00#" .. playerPhases [i][3] ..  "|r, " .. _cstr ("%.1f", playerPhases [i][4]) .. "%)")
 						GameCooltip:AddIcon ([[Interface\Garrison\orderhall-missions-mechanic9]], 1, 1, 14, 14, 11/64, 53/64, 11/64, 53/64)
 						_detalhes:AddTooltipBackgroundStatusbar()
 					end
@@ -1730,8 +1730,8 @@ function atributo_heal:MontaInfoHealTaken()
 			texCoords = _detalhes.class_coords ["UNKNOW"]
 		end
 		
-		local formated_value = SelectedToKFunction (_, _math_floor (tabela[2]))
-		self:UpdadeInfoBar (barra, index, tabela[1], tabela[1], tabela[2], formated_value, max_, tabela[3], "Interface\\AddOns\\Details\\images\\classes_small", true, texCoords)
+		local formated_value = SelectedToKFunction (nil, _math_floor (tabela[2]))
+		self:UpdadeInfoBar (barra, index, tabela[1], tabela[1], tabela[2], formated_value, maxnil, tabela[3], "Interface\\AddOns\\Details\\images\\classes_small", true, texCoords)
 	end	
 	
 end
@@ -1807,7 +1807,7 @@ function atributo_heal:MontaInfoOverHealing()
 
 		barra.lineText1:SetText (index..instancia.divisores.colocacao..tabela[4]) --seta o texto da esqueda
 		
-		local formated_value = SelectedToKFunction (_, _math_floor (tabela[2]))
+		local formated_value = SelectedToKFunction (nil, _math_floor (tabela[2]))
 		barra.lineText4:SetText (formated_value .." (".. _cstr ("%.1f", tabela[3]) .."%)")
 
 		barra.icone:SetTexture (tabela[5])
@@ -1954,14 +1954,14 @@ function atributo_heal:MontaInfoHealingDone()
 		barra.other_actor = tabela [6]
 		
 		if (info.sub_atributo == 2) then
-			local formated_value = SelectedToKFunction (_, _math_floor (tabela[2]/meu_tempo))
-			self:UpdadeInfoBar (barra, index, tabela[1], tabela[4], tabela[2], formated_value, max_, tabela[3], tabela[5], true)
+			local formated_value = SelectedToKFunction (nil, _math_floor (tabela[2]/meu_tempo))
+			self:UpdadeInfoBar (barra, index, tabela[1], tabela[4], tabela[2], formated_value, maxnil, tabela[3], tabela[5], true)
 		else
-			local formated_value = SelectedToKFunction (_, _math_floor (tabela[2]))
+			local formated_value = SelectedToKFunction (nil, _math_floor (tabela[2]))
 			if (tabela [7]) then
-				formated_value = formated_value .. " [|cFFFF5500" .. SelectedToKFunction (_, _math_floor (tabela [7])) .." " .. Loc ["STRING_DAMAGE"] .."|r] "
+				formated_value = formated_value .. " [|cFFFF5500" .. SelectedToKFunction (nil, _math_floor (tabela [7])) .." " .. Loc ["STRING_DAMAGE"] .."|r] "
 			end
-			self:UpdadeInfoBar (barra, index, tabela[1], tabela[4], tabela[2], formated_value, max_, tabela[3], tabela[5], true)
+			self:UpdadeInfoBar (barra, index, tabela[1], tabela[4], tabela[2], formated_value, maxnil, tabela[3], tabela[5], true)
 		end
 
 		barra.minha_tabela = self
@@ -2018,7 +2018,7 @@ function atributo_heal:MontaInfoHealingDone()
 		if (info.sub_atributo == 2) then
 			barra.lineText4:SetText (_detalhes:comma_value (_math_floor (tabela[2]/meu_tempo)) .." (" .. _cstr ("%.1f", tabela[3]) .. "%)")
 		else
-			barra.lineText4:SetText (SelectedToKFunction (_, tabela[2]) .. " (" .. _cstr ("%.1f", tabela[3]) .. "%)")
+			barra.lineText4:SetText (SelectedToKFunction (nil, tabela[2]) .. " (" .. _cstr ("%.1f", tabela[3]) .. "%)")
 		end
 		
 		barra.minha_tabela = self
@@ -2122,7 +2122,7 @@ function atributo_heal:MontaTooltipAlvos (thisLine, index, instancia)
 			if (is_hps) then
 				GameCooltip:AddLine (spellName, _detalhes:comma_value (_math_floor (tabela[2]/meu_tempo)).." (".. _cstr ("%.1f", tabela[2]/total*100).."%)")
 			else
-				GameCooltip:AddLine (spellName, SelectedToKFunction (_, tabela[2]).." (".. _cstr ("%.1f", tabela[2]/total*100).."%)")
+				GameCooltip:AddLine (spellName, SelectedToKFunction (nil, tabela[2]).." (".. _cstr ("%.1f", tabela[2]/total*100).."%)")
 			end
 
 			GameCooltip:AddIcon (spellIcon, nil, nil, icon_size.W + 4, icon_size.H + 4, icon_border.L, icon_border.R, icon_border.T, icon_border.B)

--- a/classes/class_instance.lua
+++ b/classes/class_instance.lua
@@ -103,7 +103,7 @@ end
 function _detalhes:InstanciaCallFunction (funcao, ...)
 	for index, instancia in _ipairs (_detalhes.tabela_instancias) do
 		if (instancia:IsAtiva()) then --> s� reabre se ela estiver ativa
-			funcao (_, instancia, ...) 
+			funcao (nil, instancia, ...) 
 		end
 	end
 end
@@ -111,7 +111,7 @@ end
 --> chama a fun��o para ser executada em todas as inst�ncias	(internal)
 function _detalhes:InstanciaCallFunctionOffline (funcao, ...)
 	for index, instancia in _ipairs (_detalhes.tabela_instancias) do
-		funcao (_, instancia, ...)
+		funcao (nil, instancia, ...)
 	end
 end
 
@@ -733,7 +733,7 @@ end
 --> cria uma nova inst�ncia e a joga para o container de inst�ncias
 
 	function _detalhes:CreateInstance (id)
-		return _detalhes:CriarInstancia (_, id)
+		return _detalhes:CriarInstancia (nil, id)
 	end
 
 	function _detalhes:CriarInstancia (_, id)
@@ -2851,7 +2851,7 @@ function _detalhes:AlteraModo (instancia, qual, from_mode_menu)
 	_detalhes.popup:Select (1, checked)
 	
 	if (from_mode_menu) then
-		instancia.baseframe.cabecalho.modo_selecao:GetScript ("OnEnter")(instancia.baseframe.cabecalho.modo_selecao, _, true)
+		instancia.baseframe.cabecalho.modo_selecao:GetScript ("OnEnter")(instancia.baseframe.cabecalho.modo_selecao, nil, true)
 		
 		--> running OnEnter does also trigger an instance enter event, so we need to manually leave the instance:
 		_detalhes.OnLeaveMainWindow (instancia, instancia.baseframe.cabecalho.modo_selecao)

--- a/classes/class_resources.lua
+++ b/classes/class_resources.lua
@@ -216,7 +216,7 @@ function atributo_energy:AtualizarResources (whichRowLine, colocacao, instancia)
 	local combat_time = instancia.showing:GetCombatTime()
 	local rps = _math_floor (self.resource / combat_time)
 	
-	local formated_resource = SelectedToKFunction (_, self.resource)
+	local formated_resource = SelectedToKFunction (nil, self.resource)
 	local formated_rps = _cstr ("%.2f", self.resource / combat_time)
 	
 	local porcentagem
@@ -677,7 +677,7 @@ function atributo_energy:RefreshLine (instancia, barras_container, whichRowLine,
 
 	local esta_porcentagem = _math_floor ((esta_e_energy_total/instancia.top) * 100)
 
-	local formated_energy = SelectedToKFunction (_, esta_e_energy_total)
+	local formated_energy = SelectedToKFunction (nil, esta_e_energy_total)
 
 	if (not bars_show_data [1]) then
 		formated_energy = ""
@@ -925,7 +925,7 @@ function atributo_energy:ToolTipRegenRecebido (instancia, numero, barra, keydown
 		end
 	
 		local nome_magia, _, icone_magia = _GetSpellInfo (spell [1])
-		GameCooltip:AddLine (nome_magia, FormatTooltipNumber (_,  spell [2]).." (".._cstr("%.1f", (spell [2]/total_regenerado) * 100).."%)")
+		GameCooltip:AddLine (nome_magia, FormatTooltipNumber (nil,  spell [2]).." (".._cstr("%.1f", (spell [2]/total_regenerado) * 100).."%)")
 		GameCooltip:AddIcon (icone_magia, nil, nil, icon_size.W, icon_size.H, icon_border.L, icon_border.R, icon_border.T, icon_border.B)
 		_detalhes:AddTooltipBackgroundStatusbar (false, spell [2] / energy_tooltips_table [1][2] * 100)
 	end
@@ -983,7 +983,7 @@ function atributo_energy:ToolTipRegenRecebido (instancia, numero, barra, keydown
 			break
 		end
 	
-		GameCooltip:AddLine (source [1], FormatTooltipNumber (_,  source [2]).." (".._cstr("%.1f", (source [2] / total_regenerado) * 100).."%)")
+		GameCooltip:AddLine (source [1], FormatTooltipNumber (nil,  source [2]).." (".._cstr("%.1f", (source [2] / total_regenerado) * 100).."%)")
 		_detalhes:AddTooltipBackgroundStatusbar()
 		
 		local classe = source [3]
@@ -1014,7 +1014,7 @@ function atributo_energy:ToolTipRegenRecebido (instancia, numero, barra, keydown
 	for i = 1, #allGeneratorSpells do
 		local thisGenerator = allGeneratorSpells [i]
 		local spellName, _, spellIcon = GetSpellInfo (thisGenerator[1].id)
-		GameCooltip:AddLine (spellName, FormatTooltipNumber (_,  thisGenerator[2]) .. " (|cFFFF5555overflow: " .. FormatTooltipNumber (_,  thisGenerator[3]) .. "|r | " .. _cstr ("%.1f", (thisGenerator[2] / allGenerated) * 100).."%)")
+		GameCooltip:AddLine (spellName, FormatTooltipNumber (nil,  thisGenerator[2]) .. " (|cFFFF5555overflow: " .. FormatTooltipNumber (nil,  thisGenerator[3]) .. "|r | " .. _cstr ("%.1f", (thisGenerator[2] / allGenerated) * 100).."%)")
 		GameCooltip:AddIcon (spellIcon, nil, nil, icon_size.W, icon_size.H, .1, .9, .1, .9)
 		_detalhes:AddTooltipBackgroundStatusbar()
 	end
@@ -1023,7 +1023,7 @@ function atributo_energy:ToolTipRegenRecebido (instancia, numero, barra, keydown
 	_detalhes:AddTooltipSpellHeaderText (self.nome .. " Auto Regen Overflow", headerColor, 1, [[Interface\CHARACTERFRAME\Disconnect-Icon]], 0.3, 0.7, 0.3, 0.7)
 	_detalhes:AddTooltipHeaderStatusbar (r, g, b, 1)
 	
-	GameCooltip:AddLine ("Auto Regen Overflow", FormatTooltipNumber (_,  self.passiveover) .. " ( " .. _cstr ("%.1f",  self.passiveover / (self.passiveover + self.total) * 100)  .. "%)")
+	GameCooltip:AddLine ("Auto Regen Overflow", FormatTooltipNumber (nil,  self.passiveover) .. " ( " .. _cstr ("%.1f",  self.passiveover / (self.passiveover + self.total) * 100)  .. "%)")
 	GameCooltip:AddIcon ([[Interface\COMMON\Indicator-Red]], nil, nil, icon_size.W, icon_size.H)
 	_detalhes:AddTooltipBackgroundStatusbar()
 	
@@ -1125,7 +1125,7 @@ function atributo_energy:MontaInfoRegenRecebido()
 		local spellname, _, spellicon = _GetSpellInfo (tabela [1])
 		local percent = tabela [2] / total_regenerado * 100
 		
-		self:UpdadeInfoBar (barra, index, tabela[1], spellname, tabela[2], _detalhes:comma_value (tabela[2]), max_, percent, spellicon, true)
+		self:UpdadeInfoBar (barra, index, tabela[1], spellname, tabela[2], _detalhes:comma_value (tabela[2]), maxnil, percent, spellicon, true)
 
 		barra.minha_tabela = self
 		barra.show = tabela[1]

--- a/classes/class_utility.lua
+++ b/classes/class_utility.lua
@@ -1178,7 +1178,7 @@ function atributo_misc:ToolTipDispell (instancia, numero, barra)
 		GameCooltip:AddLine (alvos_dispelados[i][1], _detalhes:comma_value (alvos_dispelados[i][2]) .." (".._cstr ("%.1f", alvos_dispelados[i][3]).."%)")
 		_detalhes:AddTooltipBackgroundStatusbar()
 		
-		local targetActor = instancia.showing[4]:PegarCombatente (_, alvos_dispelados[i][1])
+		local targetActor = instancia.showing[4]:PegarCombatente (nil, alvos_dispelados[i][1])
 		
 		if (targetActor) then
 			local classe = targetActor.classe
@@ -1763,7 +1763,7 @@ function atributo_misc:ToolTipDefensiveCooldowns (instancia, numero, barra)
 			
 			GameCooltip:AddIcon ("Interface\\Icons\\PALADIN_HOLY", nil, nil, icon_size.W, icon_size.H, icon_border.L, icon_border.R, icon_border.T, icon_border.B)
 			
-			local targetActor = instancia.showing[4]:PegarCombatente (_, alvos[i][1])
+			local targetActor = instancia.showing[4]:PegarCombatente (nil, alvos[i][1])
 			if (targetActor) then
 				local classe = targetActor.classe
 				if (not classe) then
@@ -1843,7 +1843,7 @@ function atributo_misc:ToolTipRess (instancia, numero, barra)
 			GameCooltip:AddLine (alvos[i][1], alvos[i][2])
 			_detalhes:AddTooltipBackgroundStatusbar()
 			
-			local targetActor = instancia.showing[4]:PegarCombatente (_, alvos[i][1])
+			local targetActor = instancia.showing[4]:PegarCombatente (nil, alvos[i][1])
 			if (targetActor) then
 				local classe = targetActor.classe
 				if (not classe) then

--- a/classes/container_actors.lua
+++ b/classes/container_actors.lua
@@ -529,7 +529,7 @@
 		--> n�o achou, criar
 		elseif (criar) then
 	
-			local novo_objeto = self.funcao_de_criacao (_, serial, nome)
+			local novo_objeto = self.funcao_de_criacao (nil, serial, nome)
 			novo_objeto.nome = nome
 			novo_objeto.flag_original = flag
 			novo_objeto.serial = serial

--- a/classes/custom_damagedone.lua
+++ b/classes/custom_damagedone.lua
@@ -124,7 +124,7 @@ function atributo_custom:damagedoneTooltip (actor, target, spellid, combat, inst
 						if (spell) then
 							local on_me = spell.targets [targetname]
 							if (on_me) then
-								GameCooltip:AddLine (aggressor.nome, FormatTooltipNumber (_, on_me))
+								GameCooltip:AddLine (aggressor.nome, FormatTooltipNumber (nil, on_me))
 								_detalhes:AddTooltipBackgroundStatusbar()
 							end
 						end
@@ -154,7 +154,7 @@ function atributo_custom:damagedoneTooltip (actor, target, spellid, combat, inst
 					break
 				end
 				
-				GameCooltip:AddLine (t[1], FormatTooltipNumber (_, t[2]))
+				GameCooltip:AddLine (t[1], FormatTooltipNumber (nil, t[2]))
 				_detalhes:AddTooltipBackgroundStatusbar()
 				GameCooltip:AddIcon ([[Interface\FriendsFrame\StatusIcon-Offline]], 1, 1, 14, 14)
 			end
@@ -172,7 +172,7 @@ function atributo_custom:damagedoneTooltip (actor, target, spellid, combat, inst
 				end
 				
 				if (roster [t[1]]) then
-					GameCooltip:AddLine (t[1], FormatTooltipNumber (_, t[2]))
+					GameCooltip:AddLine (t[1], FormatTooltipNumber (nil, t[2]))
 					_detalhes:AddTooltipBackgroundStatusbar()
 				end
 			end
@@ -180,7 +180,7 @@ function atributo_custom:damagedoneTooltip (actor, target, spellid, combat, inst
 		elseif (target == "[player]") then
 			local target_amount = actor.targets [_detalhes.playername]
 			if (target_amount) then
-				GameCooltip:AddLine (targetactor.nome, FormatTooltipNumber (_, target_amount))
+				GameCooltip:AddLine (targetactor.nome, FormatTooltipNumber (nil, target_amount))
 				_detalhes:AddTooltipBackgroundStatusbar()
 			end
 		else
@@ -194,7 +194,7 @@ function atributo_custom:damagedoneTooltip (actor, target, spellid, combat, inst
 				end
 				
 				local name, _, icon = _GetSpellInfo (t[1])
-				GameCooltip:AddLine (name, FormatTooltipNumber (_, t[2]))
+				GameCooltip:AddLine (name, FormatTooltipNumber (nil, t[2]))
 				_detalhes:AddTooltipBackgroundStatusbar()
 				GameCooltip:AddIcon (icon, 1, 1, 14, 14)
 			end

--- a/classes/custom_healingdone.lua
+++ b/classes/custom_healingdone.lua
@@ -118,7 +118,7 @@
 							if (spell) then
 								local on_me = spell.targets [targetname]
 								if (on_me) then
-									GameCooltip:AddLine (healer.nome, FormatTooltipNumber (_, on_me))
+									GameCooltip:AddLine (healer.nome, FormatTooltipNumber (nil, on_me))
 								end
 							end
 						end
@@ -147,7 +147,7 @@
 						break
 					end
 					
-					GameCooltip:AddLine (t[1], FormatTooltipNumber (_, t[2]))
+					GameCooltip:AddLine (t[1], FormatTooltipNumber (nil, t[2]))
 					_detalhes:AddTooltipBackgroundStatusbar()
 					GameCooltip:AddIcon ([[Interface\FriendsFrame\StatusIcon-Offline]], 1, 1, 14, 14)
 				end
@@ -165,14 +165,14 @@
 					end
 					
 					if (roster [t[1]]) then
-						GameCooltip:AddLine (t[1], FormatTooltipNumber (_, t[2]))
+						GameCooltip:AddLine (t[1], FormatTooltipNumber (nil, t[2]))
 					end
 				end
 				
 			elseif (target == "[player]") then
 				local target_amount = actor.targets [_detalhes.playername]
 				if (target_amount) then
-					GameCooltip:AddLine (targetactor.nome, FormatTooltipNumber (_, target_amount))
+					GameCooltip:AddLine (targetactor.nome, FormatTooltipNumber (nil, target_amount))
 				end
 				
 			else
@@ -187,7 +187,7 @@
 					end
 					
 					local name, _, icon = _GetSpellInfo (t[1])
-					GameCooltip:AddLine (name, FormatTooltipNumber (_, t[2]))
+					GameCooltip:AddLine (name, FormatTooltipNumber (nil, t[2]))
 					GameCooltip:AddIcon (icon, 1, 1, 14, 14)
 				end
 			end

--- a/core/meta.lua
+++ b/core/meta.lua
@@ -507,7 +507,7 @@
 			end
 			
 			--> tabela do combate atual
-			local tabela_atual = _detalhes.tabela_vigente or _detalhes.combate:NovaTabela (_, _detalhes.tabela_overall)
+			local tabela_atual = _detalhes.tabela_vigente or _detalhes.combate:NovaTabela (nil, _detalhes.tabela_overall)
 			
 			--> limpa a tabela overall
 			if (_detalhes.overall_clear_logout) then

--- a/core/plugins.lua
+++ b/core/plugins.lua
@@ -701,7 +701,7 @@
 		
 		function f.OpenPlugin (pluginObject)
 			--> just simulate a click on the menu button
-			f.OnMenuClick (_, _, pluginObject.real_name)
+			f.OnMenuClick (nil, nil, pluginObject.real_name)
 		end
 		
 		function f.ClosePlugin()

--- a/core/plugins_raid.lua
+++ b/core/plugins_raid.lua
@@ -105,7 +105,7 @@
 			
 			if (from_mode_menu) then
 				--refresh
-				instance.baseframe.cabecalho.modo_selecao:GetScript ("OnEnter")(instance.baseframe.cabecalho.modo_selecao, _, true)
+				instance.baseframe.cabecalho.modo_selecao:GetScript ("OnEnter")(instance.baseframe.cabecalho.modo_selecao, nil, true)
 			end
 		else
 			if (not instance.wait_for_plugin) then

--- a/core/plugins_statusbar.lua
+++ b/core/plugins_statusbar.lua
@@ -1414,7 +1414,7 @@ do
 			local window = _G.DetailsStatusBarOptions2.MyObject
 			
 			--> build all your widgets -----------------------------------------------------------------------------------------------------------------------------
-				_detalhes.gump:NewLabel (window, _, "$parentTimeTypeLabel", "TimeTypeLabel", Loc ["STRING_PLUGIN_CLOCKTYPE"])
+				_detalhes.gump:NewLabel (window, nil, "$parentTimeTypeLabel", "TimeTypeLabel", Loc ["STRING_PLUGIN_CLOCKTYPE"])
 				window.TimeTypeLabel:SetPoint (10, -15)
 				
 				local onSelectClockType = function (_, child, thistype)
@@ -1426,7 +1426,7 @@ do
 				{value = 2, label = date ("%H:%M"), onclick = onSelectClockType}
 				}
 				
-				_detalhes.gump:NewDropDown (window, _, "$parentTimeTypeDropdown", "TimeTypeDropdown", 200, 20, function() return clockTypes end, 1) -- func, default
+				_detalhes.gump:NewDropDown (window, nil, "$parentTimeTypeDropdown", "TimeTypeDropdown", 200, 20, function() return clockTypes end, 1) -- func, default
 				window.TimeTypeDropdown:SetPoint ("left", window.TimeTypeLabel, "right", 2)
 			-----------------------------------------------------------------------------------------------------------------------------
 			
@@ -1489,7 +1489,7 @@ extraWindow:SetHook ("OnHide", function()
 end)
 
 --> text style
-	_detalhes.gump:NewLabel (window, _, "$parentTextStyleLabel", "textstyle", Loc ["STRING_PLUGINOPTIONS_TEXTSTYLE"])
+	_detalhes.gump:NewLabel (window, nil, "$parentTextStyleLabel", "textstyle", Loc ["STRING_PLUGINOPTIONS_TEXTSTYLE"])
 	window.textstyle:SetPoint (10, -15)
 	
 	local onSelectTextStyle = function (_, child, style)
@@ -1513,11 +1513,11 @@ end)
 	{value = 2, label = Loc ["STRING_PLUGINOPTIONS_COMMA"] .. " (105.500)", onclick = onSelectTextStyle},
 	{value = 3, label = Loc ["STRING_PLUGINOPTIONS_NOFORMAT"] .. " (105500)", onclick = onSelectTextStyle}}
 	
-	_detalhes.gump:NewDropDown (window, _, "$parentTextStyleDropdown", "textstyleDropdown", 200, 20, function() return textStyle end, 1) -- func, default
+	_detalhes.gump:NewDropDown (window, nil, "$parentTextStyleDropdown", "textstyleDropdown", 200, 20, function() return textStyle end, 1) -- func, default
 	window.textstyleDropdown:SetPoint ("left", window.textstyle, "right", 2)
 
 --> text color
-	_detalhes.gump:NewLabel (window, _, "$parentTextColorLabel", "textcolor", Loc ["STRING_PLUGINOPTIONS_TEXTCOLOR"])
+	_detalhes.gump:NewLabel (window, nil, "$parentTextColorLabel", "textcolor", Loc ["STRING_PLUGINOPTIONS_TEXTCOLOR"])
 	window.textcolor:SetPoint (10, -35)
 	local selectedColor = function()
 		local r, g, b, a = ColorPickerFrame:GetColorRGB()
@@ -1552,15 +1552,15 @@ end)
 	window.textcolortexture:SetPoint ("left", window.textcolor, "right", 2)
 	window.textcolortexture:SetTexture (1, 1, 1)
 	
-	_detalhes.gump:NewButton (window, _, "$parentTextColorButton", "textcolorbutton", 160, 20, colorpick)
+	_detalhes.gump:NewButton (window, nil, "$parentTextColorButton", "textcolorbutton", 160, 20, colorpick)
 	window.textcolorbutton:SetPoint ("left", window.textcolor, "right", 2)
 	--window.textcolorbutton:InstallCustomTexture()
 	
 --> text size
-	_detalhes.gump:NewLabel (window, _, "$parentFontSizeLabel", "fonsizeLabel", Loc ["STRING_PLUGINOPTIONS_TEXTSIZE"])
+	_detalhes.gump:NewLabel (window, nil, "$parentFontSizeLabel", "fonsizeLabel", Loc ["STRING_PLUGINOPTIONS_TEXTSIZE"])
 	window.fonsizeLabel:SetPoint (10, -55)
 	--
-	_detalhes.gump:NewSlider (window, _, "$parentSliderFontSize", "fonsizeSlider", 170, 20, 7, 20, 1, 1)
+	_detalhes.gump:NewSlider (window, nil, "$parentSliderFontSize", "fonsizeSlider", 170, 20, 7, 20, 1, 1)
 	window.fonsizeSlider:SetPoint ("left", window.fonsizeLabel, "right", 2)
 	window.fonsizeSlider:SetThumbSize (50)
 	--window.fonsizeSlider.useDecimals = true
@@ -1590,19 +1590,19 @@ end)
 		return fontTable
 	end
 	
-	_detalhes.gump:NewLabel (window, _, "$parentFontFaceLabel", "fontfaceLabel", Loc ["STRING_PLUGINOPTIONS_FONTFACE"])
+	_detalhes.gump:NewLabel (window, nil, "$parentFontFaceLabel", "fontfaceLabel", Loc ["STRING_PLUGINOPTIONS_FONTFACE"])
 	window.fontfaceLabel:SetPoint (10, -75)
 	--
-	_detalhes.gump:NewDropDown (window, _, "$parentFontDropdown", "fontDropdown", 170, 20, buildFontMenu, nil)
+	_detalhes.gump:NewDropDown (window, nil, "$parentFontDropdown", "fontDropdown", 170, 20, buildFontMenu, nil)
 	window.fontDropdown:SetPoint ("left", window.fontfaceLabel, "right", 2)
 	
 	window:Hide()
 	
 --> align mod X
-	_detalhes.gump:NewLabel (window, _, "$parentAlignXLabel", "alignXLabel", Loc ["STRING_PLUGINOPTIONS_TEXTALIGN_X"])
+	_detalhes.gump:NewLabel (window, nil, "$parentAlignXLabel", "alignXLabel", Loc ["STRING_PLUGINOPTIONS_TEXTALIGN_X"])
 	window.alignXLabel:SetPoint (10, -115)
 	--
-	_detalhes.gump:NewSlider (window, _, "$parentSliderAlignX", "alignXSlider", 160, 20, -20, 20, 1, 0)
+	_detalhes.gump:NewSlider (window, nil, "$parentSliderAlignX", "alignXSlider", 160, 20, -20, 20, 1, 0)
 	window.alignXSlider:SetPoint ("left", window.alignXLabel, "right", 2)
 	window.alignXSlider:SetThumbSize (40)
 	window.alignXSlider:SetHook ("OnValueChange", function (self, child, amount) 
@@ -1610,10 +1610,10 @@ end)
 	end)
 	
 --> align modY
-	_detalhes.gump:NewLabel (window, _, "$parentAlignYLabel", "alignYLabel", Loc ["STRING_PLUGINOPTIONS_TEXTALIGN_Y"])
+	_detalhes.gump:NewLabel (window, nil, "$parentAlignYLabel", "alignYLabel", Loc ["STRING_PLUGINOPTIONS_TEXTALIGN_Y"])
 	window.alignYLabel:SetPoint (10, -135)
 	--
-	_detalhes.gump:NewSlider (window, _, "$parentSliderAlignY", "alignYSlider", 160, 20, -10, 10, 1, 0)
+	_detalhes.gump:NewSlider (window, nil, "$parentSliderAlignY", "alignYSlider", 160, 20, -10, 10, 1, 0)
 	window.alignYSlider:SetPoint ("left", window.alignYLabel, "right", 2)
 	window.alignYSlider:SetThumbSize (40)
 	window.alignYSlider:SetHook ("OnValueChange", function (self, child, amount) 

--- a/core/windows.lua
+++ b/core/windows.lua
@@ -938,15 +938,15 @@
 --> yes no panel
 
 	do
-		_detalhes.yesNo = _detalhes.gump:NewPanel (UIParent, _, "DetailsYesNoWindow", _, 500, 80)
+		_detalhes.yesNo = _detalhes.gump:NewPanel (UIParent, nil, "DetailsYesNoWindow", nil, 500, 80)
 		_detalhes.yesNo:SetPoint ("center", UIParent, "center")
-		_detalhes.gump:NewLabel (_detalhes.yesNo, _, "$parentAsk", "ask", "")
+		_detalhes.gump:NewLabel (_detalhes.yesNo, nil, "$parentAsk", "ask", "")
 		_detalhes.yesNo ["ask"]:SetPoint ("center", _detalhes.yesNo, "center", 0, 25)
 		_detalhes.yesNo ["ask"]:SetWidth (480)
 		_detalhes.yesNo ["ask"]:SetJustifyH ("center")
 		_detalhes.yesNo ["ask"]:SetHeight (22)
-		_detalhes.gump:NewButton (_detalhes.yesNo, _, "$parentNo", "no", 100, 30, function() _detalhes.yesNo:Hide() end, nil, nil, nil, Loc ["STRING_NO"])
-		_detalhes.gump:NewButton (_detalhes.yesNo, _, "$parentYes", "yes", 100, 30, nil, nil, nil, nil, Loc ["STRING_YES"])
+		_detalhes.gump:NewButton (_detalhes.yesNo, nil, "$parentNo", "no", 100, 30, function() _detalhes.yesNo:Hide() end, nil, nil, nil, Loc ["STRING_NO"])
+		_detalhes.gump:NewButton (_detalhes.yesNo, nil, "$parentYes", "yes", 100, 30, nil, nil, nil, nil, Loc ["STRING_YES"])
 		_detalhes.yesNo ["no"]:SetPoint (10, -45)
 		_detalhes.yesNo ["yes"]:SetPoint (390, -45)
 		_detalhes.yesNo ["no"]:InstallCustomTexture()
@@ -1228,7 +1228,7 @@
 				instance1:Enable()
 				return _detalhes:OpenOptionsWindow (instance1)
 			else
-				instance1 = _detalhes:CriarInstancia (_, true)
+				instance1 = _detalhes:CriarInstancia (nil, true)
 				if (instance1) then
 					return _detalhes:OpenOptionsWindow (instance1)
 				else
@@ -1244,7 +1244,7 @@
 	f.new_window_button:SetPoint ("topleft", f, "topleft", 10, -125)
 	f.new_window_button:SetWidth (170)
 	f.new_window_button:SetScript ("OnClick", function (self)
-		_detalhes:CriarInstancia (_, true)
+		_detalhes:CriarInstancia (nil, true)
 	end)
 
 
@@ -1341,7 +1341,7 @@
 							local lower_instance = _detalhes:GetLowerInstanceNumber()
 							if (not lower_instance) then
 								local instance = _detalhes:GetInstance (1)
-								_detalhes.CriarInstancia (_, _, 1)
+								_detalhes.CriarInstancia (nil, nil, 1)
 								_detalhes:OpenOptionsWindow (instance)
 							else
 								_detalhes:OpenOptionsWindow (_detalhes:GetInstance (lower_instance))
@@ -1464,7 +1464,7 @@
 				local lower_instance = _detalhes:GetLowerInstanceNumber()
 				if (not lower_instance) then
 					local instance = _detalhes:GetInstance (1)
-					_detalhes.CriarInstancia (_, _, 1)
+					_detalhes.CriarInstancia (nil, nil, 1)
 					_detalhes:OpenOptionsWindow (instance)
 				else
 					_detalhes:OpenOptionsWindow (_detalhes:GetInstance (lower_instance))
@@ -1483,7 +1483,7 @@
 			local lower_instance = _detalhes:GetLowerInstanceNumber()
 			if (not lower_instance) then
 				local instance = _detalhes:GetInstance (1)
-				_detalhes.CriarInstancia (_, _, 1)
+				_detalhes.CriarInstancia (nil, nil, 1)
 				_detalhes:OpenOptionsWindow (instance)
 			else
 				_detalhes:OpenOptionsWindow (_detalhes:GetInstance (lower_instance))

--- a/frames/window_benchmark.lua
+++ b/frames/window_benchmark.lua
@@ -147,7 +147,7 @@ local libwindow = LibStub("LibWindow-1.1")
                 end
                 
                 summaryFrame.TimeToTestLabel = DF:CreateLabel (summaryFrame, "Amount of Time", normal_text_template)
-                summaryFrame.TimeToTestDropdown = DF:CreateDropDown (summaryFrame, build_time_list, default, 150, 20, _, _, options_dropdown_template)
+                summaryFrame.TimeToTestDropdown = DF:CreateDropDown (summaryFrame, build_time_list, default, 150, 20, nil, nil, options_dropdown_template)
                 
             --description string and text entry
                 summaryFrame.DescriptionLabel = DF:CreateLabel (summaryFrame, "Description", normal_text_template)
@@ -167,7 +167,7 @@ local libwindow = LibStub("LibWindow-1.1")
                     return t
                 end
                 summaryFrame.BossSimulationLabel = DF:CreateLabel (summaryFrame, "Boss Simulation", normal_text_template)
-                summaryFrame.BossSimulationDropdown = DF:CreateDropDown (summaryFrame, build_bosssimulation_list, default, 150, 20, _, _, options_dropdown_template)
+                summaryFrame.BossSimulationDropdown = DF:CreateDropDown (summaryFrame, build_bosssimulation_list, default, 150, 20, nil, nil, options_dropdown_template)
                 
             --boss records line with a tooltip importing data from the storage
                 summaryFrame.BossRecordsFrame = CreateFrame ("frame", nil, summaryFrame,"BackdropTemplate")

--- a/frames/window_brokertexteditor.lua
+++ b/frames/window_brokertexteditor.lua
@@ -54,7 +54,7 @@ function Details:OpenBrokerTextEditor()
             return AddOptions
         end
         
-        local d = DF:NewDropDown (panel, _, "$parentTextOptionsDropdown", "TextOptionsDropdown", 150, 20, buildAddMenu, 1)
+        local d = DF:NewDropDown (panel, nil, "$parentTextOptionsDropdown", "TextOptionsDropdown", 150, 20, buildAddMenu, 1)
         d:SetPoint ("topright", panel, "topright", -12, -25)
         d:SetTemplate(DF:GetTemplate ("dropdown", "OPTIONS_DROPDOWN_TEMPLATE"))
 

--- a/frames/window_copy.lua
+++ b/frames/window_copy.lua
@@ -40,12 +40,12 @@ do
 		panel.TitleText:SetText ("Paste & Copy")
 		panel.portrait:SetTexture ([[Interface\CHARACTERFRAME\TEMPORARYPORTRAIT-FEMALE-BLOODELF]])
 		
-		DetailsFrameWork:NewTextEntry (panel, _, "$parentTextEntry", "text", 476, 14)
+		DetailsFrameWork:NewTextEntry (panel, nil, "$parentTextEntry", "text", 476, 14)
 		panel.text:SetPoint (20, -127)
 		panel.text:SetHook ("OnEditFocusLost", function() panel:Hide() end)
 		panel.text:SetHook ("OnChar", function() panel:Hide() end)
 		
-		DetailsFrameWork:NewLabel (panel, _, _, "desc", "paste on your web browser address bar", "OptionsFontHighlightSmall", 12)
+		DetailsFrameWork:NewLabel (panel, nil, nil, "desc", "paste on your web browser address bar", "OptionsFontHighlightSmall", 12)
 		panel.desc:SetPoint (340, -78)
 		panel.desc.width = 150
 		panel.desc.height = 25

--- a/frames/window_custom.lua
+++ b/frames/window_custom.lua
@@ -1137,7 +1137,7 @@
 					adds_boss_image:SetWidth (20)
 					adds_boss_image:SetHeight (16)
 
-					local actorsFrame = gump:NewPanel (custom_window, _, "DetailsCustomActorsFrame2", "actorsFrame", 1, 1)
+					local actorsFrame = gump:NewPanel (custom_window, nil, "DetailsCustomActorsFrame2", "actorsFrame", 1, 1)
 					actorsFrame:SetPoint ("topleft", custom_window, "topright", 5, -60)
 					actorsFrame:Hide()
 					
@@ -1282,7 +1282,7 @@
 						
 							if (_detalhes:InstanceIsRaid (instanceId)) then
 						
-								GameCooltip:AddLine (instanceTable.name, _, 1, "white")
+								GameCooltip:AddLine (instanceTable.name, nil, 1, "white")
 								GameCooltip:AddIcon (instanceTable.icon, 1, 1, 64, 32)
 
 								for index, encounterName in ipairs (instanceTable.boss_names) do 
@@ -1359,7 +1359,7 @@
 					adds_boss_image:SetWidth (20)
 					adds_boss_image:SetHeight (16)
 					
-					local actorsFrame = gump:NewPanel (custom_window, _, "DetailsCustomActorsFrame", "actorsFrame", 1, 1)
+					local actorsFrame = gump:NewPanel (custom_window, nil, "DetailsCustomActorsFrame", "actorsFrame", 1, 1)
 					actorsFrame:SetPoint ("topleft", custom_window, "topright", 5, -60)
 					actorsFrame:Hide()
 					
@@ -1490,7 +1490,7 @@
 						
 							if (_detalhes:InstanceIsRaid (instanceId)) then
 						
-								GameCooltip:AddLine (instanceTable.name, _, 1, "white")
+								GameCooltip:AddLine (instanceTable.name, nil, 1, "white")
 								GameCooltip:AddIcon (instanceTable.icon, 1, 1, 64, 32)
 
 								for index, encounterName in ipairs (instanceTable.boss_names) do 
@@ -1541,7 +1541,7 @@
 					spell_id_boss_image:SetWidth (20)
 					spell_id_boss_image:SetHeight (16)
 					
-					local spellsFrame = gump:NewPanel (custom_window, _, "DetailsCustomSpellsFrame", "spellsFrame", 1, 1)
+					local spellsFrame = gump:NewPanel (custom_window, nil, "DetailsCustomSpellsFrame", "spellsFrame", 1, 1)
 					spellsFrame:SetPoint ("topleft", custom_window, "topright", 5, 0)
 					spellsFrame:Hide()
 					
@@ -1650,7 +1650,7 @@
 						
 							if (_detalhes:InstanceisRaid (instanceId)) then
 						
-								GameCooltip:AddLine (instanceTable.name, _, 1, "white")
+								GameCooltip:AddLine (instanceTable.name, nil, 1, "white")
 								GameCooltip:AddIcon (instanceTable.icon, 1, 1, 64, 32)
 
 								for index, encounterName in ipairs (instanceTable.boss_names) do 

--- a/frames/window_main.lua
+++ b/frames/window_main.lua
@@ -2001,7 +2001,7 @@ local barra_scripts_onmouseup = function (self, button)
 				end
 				
 				if (_detalhes.row_singleclick_overwrite [self._instance.atributo] and type (_detalhes.row_singleclick_overwrite [self._instance.atributo][self._instance.sub_atributo]) == "function") then
-					return _detalhes.row_singleclick_overwrite [self._instance.atributo][self._instance.sub_atributo] (_, self.minha_tabela, self._instance, is_shift_down, is_control_down)
+					return _detalhes.row_singleclick_overwrite [self._instance.atributo][self._instance.sub_atributo] (nil, self.minha_tabela, self._instance, is_shift_down, is_control_down)
 				end
 				
 				return _detalhes:ReportSingleLine (self._instance, self)
@@ -4432,7 +4432,7 @@ local fast_ps_func = function (self)
 					local dps_text = row.ps_text
 					if (dps_text) then
 						local new_dps = _math_floor (actor.total / combat_time)
-						local formated_dps = tok_functions [ps_type] (_, new_dps)
+						local formated_dps = tok_functions [ps_type] (nil, new_dps)
 
 						--row.lineText4:SetText (row.lineText4:GetText():gsub (dps_text, formated_dps))
 						row.lineText4:SetText (( row.lineText4:GetText() or "" ):gsub (dps_text, formated_dps))
@@ -5742,11 +5742,11 @@ local OnClickNovoMenu = function (_, _, id, instance)
 		is_new = true
 	end
 
-	local ninstance = _detalhes.CriarInstancia (_, _, id)
-	instance.baseframe.cabecalho.modo_selecao:GetScript ("OnEnter")(instance.baseframe.cabecalho.modo_selecao, _, true)
+	local ninstance = _detalhes.CriarInstancia (nil, nil, id)
+	instance.baseframe.cabecalho.modo_selecao:GetScript ("OnEnter")(instance.baseframe.cabecalho.modo_selecao, nil, true)
 	
 	if (ninstance and is_new) then
-		ninstance.baseframe.cabecalho.modo_selecao:GetScript ("OnEnter")(ninstance.baseframe.cabecalho.modo_selecao, _, true)
+		ninstance.baseframe.cabecalho.modo_selecao:GetScript ("OnEnter")(ninstance.baseframe.cabecalho.modo_selecao, nil, true)
 	end
 end
 
@@ -5854,7 +5854,7 @@ local build_mode_list = function (self, elapsed)
 		end
 		
 		if (_detalhes:GetNumInstancesAmount() < _detalhes:GetMaxInstancesAmount()) then
-			CoolTip:AddMenu (2, OnClickNovoMenu, true, instancia, nil, Loc ["STRING_OPTIONS_WC_CREATE"], _, true)
+			CoolTip:AddMenu (2, OnClickNovoMenu, true, instancia, nil, Loc ["STRING_OPTIONS_WC_CREATE"], nil, true)
 			CoolTip:AddIcon ([[Interface\Buttons\UI-AttributeButton-Encourage-Up]], 2, 1, 16, 16)
 			if (HaveClosedInstances) then
 				GameCooltip:AddLine ("$div", nil, 2, nil, -5, -11)
@@ -5882,10 +5882,10 @@ local build_mode_list = function (self, elapsed)
 						_this_instance:ResetAttribute()
 						atributo = _this_instance.atributo
 						sub_atributo = _this_instance.sub_atributo
-						CoolTip:AddMenu (2, OnClickNovoMenu, index, instancia, nil, "#".. index .. " " .. _detalhes.atributos.lista [atributo] .. " - " .. _detalhes.sub_atributos [atributo].lista [sub_atributo], _, true)
+						CoolTip:AddMenu (2, OnClickNovoMenu, index, instancia, nil, "#".. index .. " " .. _detalhes.atributos.lista [atributo] .. " - " .. _detalhes.sub_atributos [atributo].lista [sub_atributo], nil, true)
 						CoolTip:AddIcon (_detalhes.sub_atributos [atributo].icones[sub_atributo] [1], 2, 1, 16, 16, unpack (_detalhes.sub_atributos [atributo].icones[sub_atributo] [2]))
 					else
-						CoolTip:AddMenu (2, OnClickNovoMenu, index, instancia, nil, "#".. index .. " " .. _detalhes.atributos.lista [atributo] .. " - " .. CustomObject:GetName(), _, true)
+						CoolTip:AddMenu (2, OnClickNovoMenu, index, instancia, nil, "#".. index .. " " .. _detalhes.atributos.lista [atributo] .. " - " .. CustomObject:GetName(), nil, true)
 						CoolTip:AddIcon (CustomObject.icon, 2, 1, 16, 16, 0, 1, 0, 1)
 					end
 
@@ -5897,10 +5897,10 @@ local build_mode_list = function (self, elapsed)
 						atributo = _detalhes.SoloTables.Mode or 1
 						local SoloInfo = _detalhes.SoloTables.Menu [atributo]
 						if (SoloInfo) then
-							CoolTip:AddMenu (2, OnClickNovoMenu, index, instancia, nil, "#".. index .. " " .. SoloInfo [1], _, true)
+							CoolTip:AddMenu (2, OnClickNovoMenu, index, instancia, nil, "#".. index .. " " .. SoloInfo [1], nil, true)
 							CoolTip:AddIcon (SoloInfo [2], 2, 1, 16, 16, 0, 1, 0, 1)
 						else
-							CoolTip:AddMenu (2, OnClickNovoMenu, index, instancia, nil, "#".. index .. " Unknown Plugin", _, true)
+							CoolTip:AddMenu (2, OnClickNovoMenu, index, instancia, nil, "#".. index .. " Unknown Plugin", nil, true)
 						end
 						
 					elseif (modo == 4) then --raid
@@ -5909,19 +5909,19 @@ local build_mode_list = function (self, elapsed)
 						if (plugin_name) then
 							local plugin_object = _detalhes:GetPlugin (plugin_name)
 							if (plugin_object) then
-								CoolTip:AddMenu (2, OnClickNovoMenu, index, instancia, nil, "#".. index .. " " .. plugin_object.__name, _, true)
+								CoolTip:AddMenu (2, OnClickNovoMenu, index, instancia, nil, "#".. index .. " " .. plugin_object.__name, nil, true)
 								CoolTip:AddIcon (plugin_object.__icon, 2, 1, 16, 16, 0, 1, 0, 1)	
 							else
-								CoolTip:AddMenu (2, OnClickNovoMenu, index, instancia, nil, "#".. index .. " Unknown Plugin", _, true)
+								CoolTip:AddMenu (2, OnClickNovoMenu, index, instancia, nil, "#".. index .. " Unknown Plugin", nil, true)
 							end
 						else
-							CoolTip:AddMenu (2, OnClickNovoMenu, index, instancia, nil, "#".. index .. " Unknown Plugin", _, true)
+							CoolTip:AddMenu (2, OnClickNovoMenu, index, instancia, nil, "#".. index .. " Unknown Plugin", nil, true)
 						end
 						
 					else
 					
-						--CoolTip:AddMenu (2, OnClickNovoMenu, index, instancia, nil, "#".. index .. " " .. _detalhes.atributos.lista [atributo] .. " - " .. _detalhes.sub_atributos [atributo].lista [sub_atributo], _, true)
-						CoolTip:AddMenu (2, OnClickNovoMenu, index, instancia, nil, "#".. index .. " " .. _detalhes.sub_atributos [atributo].lista [sub_atributo], _, true)
+						--CoolTip:AddMenu (2, OnClickNovoMenu, index, instancia, nil, "#".. index .. " " .. _detalhes.atributos.lista [atributo] .. " - " .. _detalhes.sub_atributos [atributo].lista [sub_atributo], nil, true)
+						CoolTip:AddMenu (2, OnClickNovoMenu, index, instancia, nil, "#".. index .. " " .. _detalhes.sub_atributos [atributo].lista [sub_atributo], nil, true)
 						CoolTip:AddIcon (_detalhes.sub_atributos [atributo].icones[sub_atributo] [1], 2, 1, 16, 16, unpack (_detalhes.sub_atributos [atributo].icones[sub_atributo] [2]))
 						
 					end
@@ -6310,16 +6310,16 @@ local build_segment_list = function (self, elapsed)
 						local combat_time = thisCombat:GetCombatTime()
 					
 						if (thisCombat.instance_type == "party") then
-							CoolTip:AddLine (thisCombat.is_boss.name .." (#"..i..")", _, 1, dungeon_color)
+							CoolTip:AddLine (thisCombat.is_boss.name .." (#"..i..")", nil, 1, dungeon_color)
 						elseif (thisCombat.is_boss.killed) then
 							if (try_number) then
 								local m, s = _math_floor (combat_time/60), _math_floor (combat_time%60)
 								if (s < 10) then
 									s = "0" .. s
 								end
-								CoolTip:AddLine (thisCombat.is_boss.name .." (#"..try_number.." " .. m .. ":" .. s .. ")", _, 1, "lime")
+								CoolTip:AddLine (thisCombat.is_boss.name .." (#"..try_number.." " .. m .. ":" .. s .. ")", nil, 1, "lime")
 							else
-								CoolTip:AddLine (thisCombat.is_boss.name .." (#"..i..")", _, 1, "lime")
+								CoolTip:AddLine (thisCombat.is_boss.name .." (#"..i..")", nil, 1, "lime")
 							end
 						else
 							if (try_number) then
@@ -6327,9 +6327,9 @@ local build_segment_list = function (self, elapsed)
 								if (s < 10) then
 									s = "0" .. s
 								end
-								CoolTip:AddLine (thisCombat.is_boss.name .." (#"..try_number.." " .. m .. ":" .. s .. ")", _, 1, "red")
+								CoolTip:AddLine (thisCombat.is_boss.name .." (#"..try_number.." " .. m .. ":" .. s .. ")", nil, 1, "red")
 							else
-								CoolTip:AddLine (thisCombat.is_boss.name .." (#"..i..")", _, 1, "red")
+								CoolTip:AddLine (thisCombat.is_boss.name .." (#"..i..")", nil, 1, "red")
 							end
 						end
 
@@ -6380,7 +6380,7 @@ local build_segment_list = function (self, elapsed)
 					
 					elseif (thisCombat.is_pvp) then
 						isMythicDungeon = false
-						CoolTip:AddLine (thisCombat.is_pvp.name, _, 1, battleground_color)
+						CoolTip:AddLine (thisCombat.is_pvp.name, nil, 1, battleground_color)
 						enemy = thisCombat.is_pvp.name
 						CoolTip:AddIcon ([[Interface\AddOns\Details\images\icons]], "main", "left", 16, 12, 0.251953125, 0.306640625, 0.205078125, 0.248046875)
 						
@@ -6396,7 +6396,7 @@ local build_segment_list = function (self, elapsed)
 					
 					elseif (thisCombat.is_arena) then
 						isMythicDungeon = false
-						CoolTip:AddLine (thisCombat.is_arena.name, _, 1, "yellow")
+						CoolTip:AddLine (thisCombat.is_arena.name, nil, 1, "yellow")
 						enemy = thisCombat.is_arena.name
 						CoolTip:AddIcon ([[Interface\AddOns\Details\images\icons]], "main", "left", 16, 12, 0.251953125, 0.306640625, 0.205078125, 0.248046875)
 						
@@ -6413,9 +6413,9 @@ local build_segment_list = function (self, elapsed)
 						isMythicDungeon = false
 						enemy = thisCombat.enemy
 						if (enemy) then
-							CoolTip:AddLine (thisCombat.enemy .." (#"..i..")", _, 1, "yellow")
+							CoolTip:AddLine (thisCombat.enemy .." (#"..i..")", nil, 1, "yellow")
 						else
-							CoolTip:AddLine (segmentos.past..i, _, 1, "silver")
+							CoolTip:AddLine (segmentos.past..i, nil, 1, "silver")
 						end
 						
 						if (thisCombat.is_trash) then
@@ -6447,10 +6447,10 @@ local build_segment_list = function (self, elapsed)
 					
 					fight_amount = fight_amount + 1
 				else
-					CoolTip:AddLine (Loc ["STRING_SEGMENT_LOWER"] .. " #" .. i, _, 1, "gray")
+					CoolTip:AddLine (Loc ["STRING_SEGMENT_LOWER"] .. " #" .. i, nil, 1, "gray")
 					CoolTip:AddMenu (1, instancia.TrocaTabela, i)
 					CoolTip:AddIcon ([[Interface\QUESTFRAME\UI-Quest-BulletPoint]], "main", "left", 16, 16, nil, nil, nil, nil, empty_segment_color)
-					CoolTip:AddLine (Loc ["STRING_SEGMENT_EMPTY"], _, 2)
+					CoolTip:AddLine (Loc ["STRING_SEGMENT_EMPTY"], nil, 2)
 					CoolTip:AddIcon ([[Interface\CHARACTERFRAME\Disconnect-Icon]], 2, 1, 12, 12, 0.3125, 0.65625, 0.265625, 0.671875)
 					--CoolTip:SetWallpaper (2, _detalhes.tooltip.menus_bg_texture, _detalhes.tooltip.menus_bg_coords, _detalhes.tooltip.menus_bg_color, true)
 				end
@@ -6477,7 +6477,7 @@ local build_segment_list = function (self, elapsed)
 			local segment_info_added
 			
 			--> add the new line
-			CoolTip:AddLine (segmentos.current_standard, _, 1, "white")
+			CoolTip:AddLine (segmentos.current_standard, nil, 1, "white")
 			CoolTip:AddMenu (1, instancia.TrocaTabela, 0)
 			CoolTip:AddIcon ([[Interface\QUESTFRAME\UI-Quest-BulletPoint]], "main", "left", 16, 16, nil, nil, nil, nil, "orange")
 			--
@@ -6703,8 +6703,8 @@ local build_segment_list = function (self, elapsed)
 			end
 		
 		----------- overall
-		--CoolTip:AddLine (segmentos.overall_standard, _, 1, "white") Loc ["STRING_REPORT_LAST"] .. " " .. fight_amount .. " " .. Loc ["STRING_REPORT_FIGHTS"]
-		CoolTip:AddLine (Loc ["STRING_SEGMENT_OVERALL"], _, 1, "white")
+		--CoolTip:AddLine (segmentos.overall_standard, nil, 1, "white") Loc ["STRING_REPORT_LAST"] .. " " .. fight_amount .. " " .. Loc ["STRING_REPORT_FIGHTS"]
+		CoolTip:AddLine (Loc ["STRING_SEGMENT_OVERALL"], nil, 1, "white")
 		CoolTip:AddMenu (1, instancia.TrocaTabela, -1)
 		CoolTip:AddIcon ([[Interface\QUESTFRAME\UI-Quest-BulletPoint]], "main", "left", 16, 16, nil, nil, nil, nil, "orange")
 			
@@ -9223,7 +9223,7 @@ local function click_to_change_segment (instancia, buttontype)
 		
 		instancia:TrocaTabela (segmento_goal)
 		
-		segmento_on_enter (instancia.baseframe.cabecalho.segmento.widget, _, true, true)
+		segmento_on_enter (instancia.baseframe.cabecalho.segmento.widget, nil, true, true)
 		
 	elseif (buttontype == "RightButton") then
 	
@@ -9239,7 +9239,7 @@ local function click_to_change_segment (instancia, buttontype)
 		GameCooltip:Select (1, select_)
 		
 		instancia:TrocaTabela (segmento_goal)
-		segmento_on_enter (instancia.baseframe.cabecalho.segmento.widget, _, true, true)
+		segmento_on_enter (instancia.baseframe.cabecalho.segmento.widget, nil, true, true)
 	
 	elseif (buttontype == "MiddleButton") then
 		
@@ -9252,7 +9252,7 @@ local function click_to_change_segment (instancia, buttontype)
 		GameCooltip:Select (1, select_)
 		
 		instancia:TrocaTabela (segmento_goal)
-		segmento_on_enter (instancia.baseframe.cabecalho.segmento.widget, _, true, true)
+		segmento_on_enter (instancia.baseframe.cabecalho.segmento.widget, nil, true, true)
 		
 	end
 end
@@ -9420,7 +9420,7 @@ function gump:CriaCabecalho (baseframe, instancia)
 				GameCooltip:ShowMe (false)
 				instancia.LastMenuOpened = nil
 			else		
-				modo_selecao_on_enter (instancia.baseframe.cabecalho.modo_selecao.widget, _, true, true)
+				modo_selecao_on_enter (instancia.baseframe.cabecalho.modo_selecao.widget, nil, true, true)
 				instancia.LastMenuOpened = "mode"
 			end
 		else
@@ -9452,7 +9452,7 @@ function gump:CriaCabecalho (baseframe, instancia)
 				GameCooltip:ShowMe (false)
 				instancia.LastMenuOpened = nil
 			else
-				segmento_on_enter (instancia.baseframe.cabecalho.segmento.widget, _, true, true)
+				segmento_on_enter (instancia.baseframe.cabecalho.segmento.widget, nil, true, true)
 				instancia.LastMenuOpened = "segments"
 			end
 		else
@@ -9486,7 +9486,7 @@ function gump:CriaCabecalho (baseframe, instancia)
 				GameCooltip:ShowMe (false)
 				instancia.LastMenuOpened = nil
 			else
-				atributo_on_enter (instancia.baseframe.cabecalho.atributo.widget, _, true, true)
+				atributo_on_enter (instancia.baseframe.cabecalho.atributo.widget, nil, true, true)
 				instancia.LastMenuOpened = "attributes"
 			end
 		end
@@ -9540,7 +9540,7 @@ function gump:CriaCabecalho (baseframe, instancia)
 				GameCooltip:ShowMe (false)
 				instancia.LastMenuOpened = nil
 			else
-				reset_button_onenter (instancia.baseframe.cabecalho.reset, _, true, true)
+				reset_button_onenter (instancia.baseframe.cabecalho.reset, nil, true, true)
 				instancia.LastMenuOpened = "reset"
 			end
 		else

--- a/frames/window_news.lua
+++ b/frames/window_news.lua
@@ -158,7 +158,7 @@ function Details:CreateOrOpenNewsWindow()
 		local onToggleAutoOpen = function(_, _, state)
 			Details.auto_open_news_window = state
 		end
-		local autoOpenCheckbox = DetailsFramework:CreateSwitch(statusBar, onToggleAutoOpen, Details.auto_open_news_window, _, _, _, _, "AutoOpenCheckbox", _, _, _, _, _, DetailsFramework:GetTemplate ("switch", "OPTIONS_CHECKBOX_BRIGHT_TEMPLATE"))
+		local autoOpenCheckbox = DetailsFramework:CreateSwitch(statusBar, onToggleAutoOpen, Details.auto_open_news_window, nil, nil, nil, nil, "AutoOpenCheckbox", nil, nil, nil, nil, nil, DetailsFramework:GetTemplate ("switch", "OPTIONS_CHECKBOX_BRIGHT_TEMPLATE"))
 		autoOpenCheckbox:SetAsCheckBox()
 		autoOpenCheckbox:SetPoint("left", statusBar, "left", 2, 0)
 

--- a/frames/window_options2.lua
+++ b/frames/window_options2.lua
@@ -41,7 +41,7 @@ function Details:InitializeOptionsWindow(instance)
 end
 
 function Details.options.InitializeOptionsWindow(instance)
-	local DetailsOptionsWindow = DF:NewPanel(UIParent, _, "DetailsOptionsWindow", _, 897, 592)
+	local DetailsOptionsWindow = DF:NewPanel(UIParent, nil, "DetailsOptionsWindow", nil, 897, 592)
     local f = DetailsOptionsWindow.frame
 
 	f.Frame = f
@@ -77,7 +77,7 @@ function Details.options.InitializeOptionsWindow(instance)
         local instance = _detalhes.tabela_instancias[instanceId]
         
         if (not instance:IsEnabled() or not instance:IsStarted()) then
-            _detalhes.CriarInstancia (_, _, instance.meu_id)
+            _detalhes.CriarInstancia (nil, nil, instance.meu_id)
         end
         
         Details.options.SetCurrentInstance(instance)
@@ -135,7 +135,7 @@ function Details.options.InitializeOptionsWindow(instance)
         return instanceList
     end
     
-    local instanceSelection = DF:NewDropDown (f, _, "$parentInstanceSelectDropdown", "instanceDropdown", 200, 18, buildInstanceMenu) --, nil, options_dropdown_template
+    local instanceSelection = DF:NewDropDown (f, nil, "$parentInstanceSelectDropdown", "instanceDropdown", 200, 18, buildInstanceMenu) --, nil, options_dropdown_template
     instanceSelection:SetPoint("bottomright", f, "bottomright", -7, 09)
     instanceSelection:SetHook("OnEnter", function()
         GameCooltip:Reset()
@@ -158,7 +158,7 @@ function Details.options.InitializeOptionsWindow(instance)
     local onToggleEditingGroup = function(self, fixparam, value)
         _detalhes.options_group_edit = value
     end
-    local editingGroupCheckBox = DF:CreateSwitch(f, onToggleEditingGroup, _detalhes.options_group_edit, _, _, _, _, _, "$parentEditGroupCheckbox", _, _, _, _, DF:GetTemplate("switch", "OPTIONS_CHECKBOX_BRIGHT_TEMPLATE"))
+    local editingGroupCheckBox = DF:CreateSwitch(f, onToggleEditingGroup, _detalhes.options_group_edit, nil, nil, nil, nil, nil, "$parentEditGroupCheckbox", nil, nil, nil, nil, DF:GetTemplate("switch", "OPTIONS_CHECKBOX_BRIGHT_TEMPLATE"))
     editingGroupCheckBox:SetAsCheckBox()
     editingGroupCheckBox.tooltip = Loc ["STRING_MINITUTORIAL_OPTIONS_PANEL2"]
 
@@ -177,13 +177,13 @@ function Details.options.InitializeOptionsWindow(instance)
             _detalhes:StopTestBarUpdate()
         end
     end
-    local fillbars = DF:NewButton (f, _, "$parentCreateExampleBarsButton", nil, 140, 20, create_test_bars_func, nil, nil, nil, Loc ["STRING_OPTIONS_TESTBARS"], 1)
+    local fillbars = DF:NewButton (f, nil, "$parentCreateExampleBarsButton", nil, 140, 20, create_test_bars_func, nil, nil, nil, Loc ["STRING_OPTIONS_TESTBARS"], 1)
     fillbars:SetPoint ("bottomleft", f.widget, "bottomleft", 10, 10)
     fillbars:SetTemplate(options_button_template)
     fillbars:SetIcon ("Interface\\AddOns\\Details\\images\\icons", nil, nil, nil, {323/512, 365/512, 42/512, 78/512}, {1, 1, 1, 0.6}, 4, 2)
 
     --change log
-    local changelog = DF:NewButton (f, _, "$parentOpenChangeLogButton", nil, 140, 20, _detalhes.OpenNewsWindow, "change_log", nil, nil, Loc ["STRING_OPTIONS_CHANGELOG"], 1)
+    local changelog = DF:NewButton (f, nil, "$parentOpenChangeLogButton", nil, 140, 20, _detalhes.OpenNewsWindow, "change_log", nil, nil, Loc ["STRING_OPTIONS_CHANGELOG"], 1)
     changelog:SetPoint ("left", fillbars, "right", 10, 0)
     changelog:SetTemplate (options_button_template)
     changelog:SetIcon ("Interface\\AddOns\\Details\\images\\icons", nil, nil, nil, {367/512, 399/512, 43/512, 76/512}, {1, 1, 1, 0.8}, 4, 2)
@@ -274,7 +274,7 @@ function Details.options.InitializeOptionsWindow(instance)
 			local lowerInstance = Details:GetLowerInstanceNumber()
 			if (not lowerInstance) then
 				local instance = Details:GetInstance(1)
-				Details.CriarInstancia(_, _, 1)
+				Details.CriarInstancia(nil, nil, 1)
 				Details:OpenOptionsWindow(instance)
 			else
 				Details:OpenOptionsWindow(Details:GetInstance(lowerInstance))

--- a/frames/window_options2_sections.lua
+++ b/frames/window_options2_sections.lua
@@ -2758,11 +2758,11 @@ do
         do --> micro displays
             
             --statics texts
-            DF:NewLabel (sectionFrame, _, "$parentMicroDisplaysAnchor", "MicroDisplaysAnchor", Loc ["STRING_OPTIONS_MICRODISPLAY_ANCHOR"], "GameFontNormal")
-            DF:NewLabel (sectionFrame, _, "$parentMicroDisplayLeftLabel", "MicroDisplayLeftLabel", Loc ["STRING_ANCHOR_LEFT"], "GameFontHighlightLeft")
-            DF:NewLabel (sectionFrame, _, "$parentMicroDisplayCenterLabel", "MicroDisplayCenterLabel", Loc ["STRING_CENTER_UPPER"], "GameFontHighlightLeft")
-            DF:NewLabel (sectionFrame, _, "$parentMicroDisplayRightLabel", "MicroDisplayRightLabel", Loc ["STRING_ANCHOR_RIGHT"], "GameFontHighlightLeft")
-            DF:NewLabel (sectionFrame, _, "$parentMicroDisplayWarningLabel", "MicroDisplayWarningLabel", Loc ["STRING_OPTIONS_MICRODISPLAYS_WARNING"], "GameFontHighlightSmall", 10, "orange")
+            DF:NewLabel (sectionFrame, nil, "$parentMicroDisplaysAnchor", "MicroDisplaysAnchor", Loc ["STRING_OPTIONS_MICRODISPLAY_ANCHOR"], "GameFontNormal")
+            DF:NewLabel (sectionFrame, nil, "$parentMicroDisplayLeftLabel", "MicroDisplayLeftLabel", Loc ["STRING_ANCHOR_LEFT"], "GameFontHighlightLeft")
+            DF:NewLabel (sectionFrame, nil, "$parentMicroDisplayCenterLabel", "MicroDisplayCenterLabel", Loc ["STRING_CENTER_UPPER"], "GameFontHighlightLeft")
+            DF:NewLabel (sectionFrame, nil, "$parentMicroDisplayRightLabel", "MicroDisplayRightLabel", Loc ["STRING_ANCHOR_RIGHT"], "GameFontHighlightLeft")
+            DF:NewLabel (sectionFrame, nil, "$parentMicroDisplayWarningLabel", "MicroDisplayWarningLabel", Loc ["STRING_OPTIONS_MICRODISPLAYS_WARNING"], "GameFontHighlightSmall", 10, "orange")
 
             --dropdown on select option
             local onMicroDisplaySelect = function (_, _, micro_display)
@@ -2806,9 +2806,9 @@ do
             local dropdown_height = 18
 
             --create dropdowns
-            DF:NewDropDown (sectionFrame, _, "$parentMicroDisplayLeftDropdown", "MicroDisplayLeftDropdown", DROPDOWN_WIDTH, dropdown_height, buildLeftMicroMenu, nil, options_dropdown_template)
-            DF:NewDropDown (sectionFrame, _, "$parentMicroDisplayCenterDropdown", "MicroDisplayCenterDropdown", DROPDOWN_WIDTH, dropdown_height, buildCenterMicroMenu, nil, options_dropdown_template)
-            DF:NewDropDown (sectionFrame, _, "$parentMicroDisplayRightDropdown", "MicroDisplayRightDropdown", DROPDOWN_WIDTH, dropdown_height, buildRightMicroMenu, nil, options_dropdown_template)
+            DF:NewDropDown (sectionFrame, nil, "$parentMicroDisplayLeftDropdown", "MicroDisplayLeftDropdown", DROPDOWN_WIDTH, dropdown_height, buildLeftMicroMenu, nil, options_dropdown_template)
+            DF:NewDropDown (sectionFrame, nil, "$parentMicroDisplayCenterDropdown", "MicroDisplayCenterDropdown", DROPDOWN_WIDTH, dropdown_height, buildCenterMicroMenu, nil, options_dropdown_template)
+            DF:NewDropDown (sectionFrame, nil, "$parentMicroDisplayRightDropdown", "MicroDisplayRightDropdown", DROPDOWN_WIDTH, dropdown_height, buildRightMicroMenu, nil, options_dropdown_template)
             
             sectionFrame.MicroDisplayLeftDropdown:SetPoint ("left", sectionFrame.MicroDisplayLeftLabel, "right", 2)
             sectionFrame.MicroDisplayCenterDropdown:SetPoint ("left", sectionFrame.MicroDisplayCenterLabel, "right", 2)
@@ -2819,7 +2819,7 @@ do
             sectionFrame.MicroDisplayRightDropdown.tooltip = Loc ["STRING_OPTIONS_MICRODISPLAYS_DROPDOWN_TOOLTIP"]
             
 
-            local hideLeftMicroFrameButton = DF:NewButton (sectionFrame.MicroDisplayLeftDropdown, _, "$parenthideLeftMicroFrameButton", "hideLeftMicroFrameButton", 22, 22, function (self, button)
+            local hideLeftMicroFrameButton = DF:NewButton (sectionFrame.MicroDisplayLeftDropdown, nil, "$parenthideLeftMicroFrameButton", "hideLeftMicroFrameButton", 22, 22, function (self, button)
                 if (currentInstance.StatusBar ["left"].options.isHidden) then
                     _detalhes.StatusBar:SetPlugin (currentInstance, currentInstance.StatusBar ["left"].real_name, "left")
                 else
@@ -2844,7 +2844,7 @@ do
                 self:GetNormalTexture():SetBlendMode("BLEND")
             end)
 
-            local HideCenterMicroFrameButton = DF:NewButton (sectionFrame.MicroDisplayCenterDropdown, _, "$parentHideCenterMicroFrameButton", "HideCenterMicroFrameButton", 22, 22, function (self)
+            local HideCenterMicroFrameButton = DF:NewButton (sectionFrame.MicroDisplayCenterDropdown, nil, "$parentHideCenterMicroFrameButton", "HideCenterMicroFrameButton", 22, 22, function (self)
                 if (currentInstance.StatusBar ["center"].options.isHidden) then
                     _detalhes.StatusBar:SetPlugin (currentInstance, currentInstance.StatusBar ["center"].real_name, "center")
                 else
@@ -2869,7 +2869,7 @@ do
                 self:GetNormalTexture():SetBlendMode("BLEND")
             end)
             
-            local HideRightMicroFrameButton = DF:NewButton (sectionFrame.MicroDisplayRightDropdown, _, "$parentHideRightMicroFrameButton", "HideRightMicroFrameButton", 20, 20, function (self)
+            local HideRightMicroFrameButton = DF:NewButton (sectionFrame.MicroDisplayRightDropdown, nil, "$parentHideRightMicroFrameButton", "HideRightMicroFrameButton", 20, 20, function (self)
                 if (currentInstance.StatusBar ["right"].options.isHidden) then
                     _detalhes.StatusBar:SetPlugin (currentInstance, currentInstance.StatusBar ["right"].real_name, "right")
                 else
@@ -2893,7 +2893,7 @@ do
                 self:GetNormalTexture():SetBlendMode("BLEND")
             end)
 
-            local configRightMicroFrameButton = DF:NewButton (sectionFrame.MicroDisplayRightDropdown, _, "$parentconfigRightMicroFrameButton", "configRightMicroFrameButton", 18, 18, function (self)
+            local configRightMicroFrameButton = DF:NewButton (sectionFrame.MicroDisplayRightDropdown, nil, "$parentconfigRightMicroFrameButton", "configRightMicroFrameButton", 18, 18, function (self)
                 currentInstance.StatusBar ["right"]:Setup()
                 currentInstance.StatusBar ["right"]:Setup()
             end)
@@ -2902,7 +2902,7 @@ do
             configRightMicroFrameButton:SetHighlightTexture ([[Interface\Buttons\UI-OptionsButton]])
             configRightMicroFrameButton.tooltip = Loc ["STRING_OPTIONS_MICRODISPLAYS_OPTION_TOOLTIP"]
             
-            local configCenterMicroFrameButton = DF:NewButton (sectionFrame.MicroDisplayCenterDropdown, _, "$parentconfigCenterMicroFrameButton", "configCenterMicroFrameButton", 18, 18, function (self)
+            local configCenterMicroFrameButton = DF:NewButton (sectionFrame.MicroDisplayCenterDropdown, nil, "$parentconfigCenterMicroFrameButton", "configCenterMicroFrameButton", 18, 18, function (self)
                 currentInstance.StatusBar ["center"]:Setup()
                 currentInstance.StatusBar ["center"]:Setup()
             end)
@@ -2911,7 +2911,7 @@ do
             configCenterMicroFrameButton:SetHighlightTexture ([[Interface\Buttons\UI-OptionsButton]])
             configCenterMicroFrameButton.tooltip = Loc ["STRING_OPTIONS_MICRODISPLAYS_OPTION_TOOLTIP"]
             
-            local configLeftMicroFrameButton = DF:NewButton (sectionFrame.MicroDisplayLeftDropdown, _, "$parentconfigLeftMicroFrameButton", "configLeftMicroFrameButton", 18, 18, function (self)
+            local configLeftMicroFrameButton = DF:NewButton (sectionFrame.MicroDisplayLeftDropdown, nil, "$parentconfigLeftMicroFrameButton", "configLeftMicroFrameButton", 18, 18, function (self)
                 currentInstance.StatusBar ["left"]:Setup()
                 currentInstance.StatusBar ["left"]:Setup()
             end)
@@ -3004,7 +3004,7 @@ do
         local y = -20
         
         --> toolbar
-        DF:NewLabel (anchorFrame, _, "$parentToolbarPluginsLabel", "toolbarLabel", Loc ["STRING_OPTIONS_PLUGINS_TOOLBAR_ANCHOR"], "GameFontNormal", 16)
+        DF:NewLabel (anchorFrame, nil, "$parentToolbarPluginsLabel", "toolbarLabel", Loc ["STRING_OPTIONS_PLUGINS_TOOLBAR_ANCHOR"], "GameFontNormal", 16)
         anchorFrame.toolbarLabel:SetPoint ("topleft", anchorFrame, "topleft", 10, y)
         
         y = y - 30
@@ -3014,15 +3014,15 @@ do
             descbar:SetTexture (.3, .3, .3, .8)
             descbar:SetPoint ("topleft", anchorFrame, "topleft", 5, y+3)
             descbar:SetSize (650, 20)
-            DF:NewLabel (anchorFrame, _, "$parentDescNameLabel", "descNameLabel", Loc ["STRING_OPTIONS_PLUGINS_NAME"], "GameFontNormal", 12)
+            DF:NewLabel (anchorFrame, nil, "$parentDescNameLabel", "descNameLabel", Loc ["STRING_OPTIONS_PLUGINS_NAME"], "GameFontNormal", 12)
             anchorFrame.descNameLabel:SetPoint ("topleft", anchorFrame, "topleft", 15, y)
-            DF:NewLabel (anchorFrame, _, "$parentDescAuthorLabel", "descAuthorLabel", Loc ["STRING_OPTIONS_PLUGINS_AUTHOR"], "GameFontNormal", 12)
+            DF:NewLabel (anchorFrame, nil, "$parentDescAuthorLabel", "descAuthorLabel", Loc ["STRING_OPTIONS_PLUGINS_AUTHOR"], "GameFontNormal", 12)
             anchorFrame.descAuthorLabel:SetPoint ("topleft", anchorFrame, "topleft", 180, y)
-            DF:NewLabel (anchorFrame, _, "$parentDescVersionLabel", "descVersionLabel", Loc ["STRING_OPTIONS_PLUGINS_VERSION"], "GameFontNormal", 12)
+            DF:NewLabel (anchorFrame, nil, "$parentDescVersionLabel", "descVersionLabel", Loc ["STRING_OPTIONS_PLUGINS_VERSION"], "GameFontNormal", 12)
             anchorFrame.descVersionLabel:SetPoint ("topleft", anchorFrame, "topleft", 290, y)
-            DF:NewLabel (anchorFrame, _, "$parentDescEnabledLabel", "descEnabledLabel", Loc ["STRING_ENABLED"], "GameFontNormal", 12)
+            DF:NewLabel (anchorFrame, nil, "$parentDescEnabledLabel", "descEnabledLabel", Loc ["STRING_ENABLED"], "GameFontNormal", 12)
             anchorFrame.descEnabledLabel:SetPoint ("topleft", anchorFrame, "topleft", 400, y)
-            DF:NewLabel (anchorFrame, _, "$parentDescOptionsLabel", "descOptionsLabel", Loc ["STRING_OPTIONS_PLUGINS_OPTIONS"], "GameFontNormal", 12)
+            DF:NewLabel (anchorFrame, nil, "$parentDescOptionsLabel", "descOptionsLabel", Loc ["STRING_OPTIONS_PLUGINS_OPTIONS"], "GameFontNormal", 12)
             anchorFrame.descOptionsLabel:SetPoint ("topleft", anchorFrame, "topleft", 510, y)
         end
         
@@ -3069,18 +3069,18 @@ do
             DF:NewImage (bframe, pluginObject.__icon, 18, 18, nil, nil, "toolbarPluginsIcon"..i, "$parentToolbarPluginsIcon"..i)
             bframe ["toolbarPluginsIcon"..i]:SetPoint ("topleft", anchorFrame, "topleft", 10, y)
         
-            DF:NewLabel (bframe, _, "$parentToolbarPluginsLabel"..i, "toolbarPluginsLabel"..i, pluginObject.__name)
+            DF:NewLabel (bframe, nil, "$parentToolbarPluginsLabel"..i, "toolbarPluginsLabel"..i, pluginObject.__name)
             bframe ["toolbarPluginsLabel"..i]:SetPoint ("left", bframe ["toolbarPluginsIcon"..i], "right", 2, 0)
             
-            DF:NewLabel (bframe, _, "$parentToolbarPluginsLabel2"..i, "toolbarPluginsLabel2"..i, pluginObject.__author)
+            DF:NewLabel (bframe, nil, "$parentToolbarPluginsLabel2"..i, "toolbarPluginsLabel2"..i, pluginObject.__author)
             bframe ["toolbarPluginsLabel2"..i]:SetPoint ("topleft", anchorFrame, "topleft", 180, y-4)
             
-            DF:NewLabel (bframe, _, "$parentToolbarPluginsLabel3"..i, "toolbarPluginsLabel3"..i, pluginObject.__version)
+            DF:NewLabel (bframe, nil, "$parentToolbarPluginsLabel3"..i, "toolbarPluginsLabel3"..i, pluginObject.__version)
             bframe ["toolbarPluginsLabel3"..i]:SetPoint ("topleft", anchorFrame, "topleft", 290, y-4)
             
             local plugin_stable = _detalhes:GetPluginSavedTable (absName)
             local plugin = _detalhes:GetPlugin (absName)
-            DF:NewSwitch (bframe, _, "$parentToolbarSlider"..i, "toolbarPluginsSlider"..i, 60, 20, _, _, plugin_stable.enabled, nil, nil, nil, nil, options_switch_template)
+            DF:NewSwitch (bframe, nil, "$parentToolbarSlider"..i, "toolbarPluginsSlider"..i, 60, 20, nil, nil, plugin_stable.enabled, nil, nil, nil, nil, options_switch_template)
             bframe ["toolbarPluginsSlider"..i].PluginName = absName
             tinsert (anchorFrame.plugin_widgets, bframe ["toolbarPluginsSlider"..i])
             bframe ["toolbarPluginsSlider"..i]:SetPoint ("topleft", anchorFrame, "topleft", 415, y)
@@ -3139,15 +3139,15 @@ do
                 DF:NewImage (bframe, pluginObject.__icon, 18, 18, nil, nil, "toolbarPluginsIcon"..i, "$parentToolbarPluginsIcon"..i)
                 bframe ["toolbarPluginsIcon"..i]:SetPoint ("topleft", anchorFrame, "topleft", 10, y)
             
-                DF:NewLabel (bframe, _, "$parentToolbarPluginsLabel"..i, "toolbarPluginsLabel"..i, pluginObject.__name)
+                DF:NewLabel (bframe, nil, "$parentToolbarPluginsLabel"..i, "toolbarPluginsLabel"..i, pluginObject.__name)
                 bframe ["toolbarPluginsLabel"..i]:SetPoint ("left", bframe ["toolbarPluginsIcon"..i], "right", 2, 0)
                 bframe ["toolbarPluginsLabel"..i].color = notInstalledColor
                 
-                DF:NewLabel (bframe, _, "$parentToolbarPluginsLabel2"..i, "toolbarPluginsLabel2"..i, pluginObject.__author)
+                DF:NewLabel (bframe, nil, "$parentToolbarPluginsLabel2"..i, "toolbarPluginsLabel2"..i, pluginObject.__author)
                 bframe ["toolbarPluginsLabel2"..i]:SetPoint ("topleft", anchorFrame, "topleft", 180, y-4)
                 bframe ["toolbarPluginsLabel2"..i].color = notInstalledColor
                 
-                DF:NewLabel (bframe, _, "$parentToolbarPluginsLabel3"..i, "toolbarPluginsLabel3"..i, pluginObject.__version)
+                DF:NewLabel (bframe, nil, "$parentToolbarPluginsLabel3"..i, "toolbarPluginsLabel3"..i, pluginObject.__version)
                 bframe ["toolbarPluginsLabel3"..i]:SetPoint ("topleft", anchorFrame, "topleft", 290, y-4)
                 bframe ["toolbarPluginsLabel3"..i].color = notInstalledColor
     
@@ -3163,7 +3163,7 @@ do
         y = y - 10
         
         --raid
-        DF:NewLabel (anchorFrame, _, "$parentRaidPluginsLabel", "raidLabel", Loc ["STRING_OPTIONS_PLUGINS_RAID_ANCHOR"], "GameFontNormal", 16)
+        DF:NewLabel (anchorFrame, nil, "$parentRaidPluginsLabel", "raidLabel", Loc ["STRING_OPTIONS_PLUGINS_RAID_ANCHOR"], "GameFontNormal", 16)
         anchorFrame.raidLabel:SetPoint ("topleft", anchorFrame, "topleft", 10, y)
         
         y = y - 30
@@ -3173,15 +3173,15 @@ do
             descbar:SetTexture (.3, .3, .3, .8)
             descbar:SetPoint ("topleft", anchorFrame, "topleft", 5, y+3)
             descbar:SetSize (650, 20)
-            DF:NewLabel (anchorFrame, _, "$parentDescNameLabel2", "descNameLabel", Loc ["STRING_OPTIONS_PLUGINS_NAME"], "GameFontNormal", 12)
+            DF:NewLabel (anchorFrame, nil, "$parentDescNameLabel2", "descNameLabel", Loc ["STRING_OPTIONS_PLUGINS_NAME"], "GameFontNormal", 12)
             anchorFrame.descNameLabel:SetPoint ("topleft", anchorFrame, "topleft", 15, y)
-            DF:NewLabel (anchorFrame, _, "$parentDescAuthorLabel2", "descAuthorLabel", Loc ["STRING_OPTIONS_PLUGINS_AUTHOR"], "GameFontNormal", 12)
+            DF:NewLabel (anchorFrame, nil, "$parentDescAuthorLabel2", "descAuthorLabel", Loc ["STRING_OPTIONS_PLUGINS_AUTHOR"], "GameFontNormal", 12)
             anchorFrame.descAuthorLabel:SetPoint ("topleft", anchorFrame, "topleft", 180, y)
-            DF:NewLabel (anchorFrame, _, "$parentDescVersionLabel2", "descVersionLabel", Loc ["STRING_OPTIONS_PLUGINS_VERSION"], "GameFontNormal", 12)
+            DF:NewLabel (anchorFrame, nil, "$parentDescVersionLabel2", "descVersionLabel", Loc ["STRING_OPTIONS_PLUGINS_VERSION"], "GameFontNormal", 12)
             anchorFrame.descVersionLabel:SetPoint ("topleft", anchorFrame, "topleft", 290, y)
-            DF:NewLabel (anchorFrame, _, "$parentDescEnabledLabel2", "descEnabledLabel", Loc ["STRING_ENABLED"], "GameFontNormal", 12)
+            DF:NewLabel (anchorFrame, nil, "$parentDescEnabledLabel2", "descEnabledLabel", Loc ["STRING_ENABLED"], "GameFontNormal", 12)
             anchorFrame.descEnabledLabel:SetPoint ("topleft", anchorFrame, "topleft", 400, y)
-            DF:NewLabel (anchorFrame, _, "$parentDescOptionsLabel2", "descOptionsLabel", Loc ["STRING_OPTIONS_PLUGINS_OPTIONS"], "GameFontNormal", 12)
+            DF:NewLabel (anchorFrame, nil, "$parentDescOptionsLabel2", "descOptionsLabel", Loc ["STRING_OPTIONS_PLUGINS_OPTIONS"], "GameFontNormal", 12)
             anchorFrame.descOptionsLabel:SetPoint ("topleft", anchorFrame, "topleft", 510, y)
         end
         
@@ -3204,18 +3204,18 @@ do
             DF:NewImage (bframe, pluginObject.__icon, 18, 18, nil, nil, "raidPluginsIcon"..i, "$parentRaidPluginsIcon"..i)
             bframe ["raidPluginsIcon"..i]:SetPoint ("topleft", anchorFrame, "topleft", 10, y)
         
-            DF:NewLabel (bframe, _, "$parentRaidPluginsLabel"..i, "raidPluginsLabel"..i, pluginObject.__name)
+            DF:NewLabel (bframe, nil, "$parentRaidPluginsLabel"..i, "raidPluginsLabel"..i, pluginObject.__name)
             bframe ["raidPluginsLabel"..i]:SetPoint ("left", bframe ["raidPluginsIcon"..i], "right", 2, 0)
             
-            DF:NewLabel (bframe, _, "$parentRaidPluginsLabel2"..i, "raidPluginsLabel2"..i, pluginObject.__author)
+            DF:NewLabel (bframe, nil, "$parentRaidPluginsLabel2"..i, "raidPluginsLabel2"..i, pluginObject.__author)
             bframe ["raidPluginsLabel2"..i]:SetPoint ("topleft", anchorFrame, "topleft", 180, y-4)
             
-            DF:NewLabel (bframe, _, "$parentRaidPluginsLabel3"..i, "raidPluginsLabel3"..i, pluginObject.__version)
+            DF:NewLabel (bframe, nil, "$parentRaidPluginsLabel3"..i, "raidPluginsLabel3"..i, pluginObject.__version)
             bframe ["raidPluginsLabel3"..i]:SetPoint ("topleft", anchorFrame, "topleft", 290, y-4)
             
             local plugin_stable = _detalhes:GetPluginSavedTable (absName)
             local plugin = _detalhes:GetPlugin (absName)
-            DF:NewSwitch (bframe, _, "$parentRaidSlider"..i, "raidPluginsSlider"..i, 60, 20, _, _, plugin_stable.enabled, nil, nil, nil, nil, options_switch_template)
+            DF:NewSwitch (bframe, nil, "$parentRaidSlider"..i, "raidPluginsSlider"..i, 60, 20, nil, nil, plugin_stable.enabled, nil, nil, nil, nil, options_switch_template)
             tinsert (anchorFrame.plugin_widgets, bframe ["raidPluginsSlider"..i])
             bframe ["raidPluginsSlider"..i].PluginName = absName
             bframe ["raidPluginsSlider"..i]:SetPoint ("topleft", anchorFrame, "topleft", 415, y+1)
@@ -3277,15 +3277,15 @@ do
                 DF:NewImage (bframe, pluginObject.__icon, 18, 18, nil, nil, "toolbarPluginsIcon"..i, "$parentToolbarPluginsIcon"..i)
                 bframe ["toolbarPluginsIcon"..i]:SetPoint ("topleft", anchorFrame, "topleft", 10, y)
             
-                DF:NewLabel (bframe, _, "$parentToolbarPluginsLabel"..i, "toolbarPluginsLabel"..i, pluginObject.__name)
+                DF:NewLabel (bframe, nil, "$parentToolbarPluginsLabel"..i, "toolbarPluginsLabel"..i, pluginObject.__name)
                 bframe ["toolbarPluginsLabel"..i]:SetPoint ("left", bframe ["toolbarPluginsIcon"..i], "right", 2, 0)
                 bframe ["toolbarPluginsLabel"..i].color = notInstalledColor
                 
-                DF:NewLabel (bframe, _, "$parentToolbarPluginsLabel2"..i, "toolbarPluginsLabel2"..i, pluginObject.__author)
+                DF:NewLabel (bframe, nil, "$parentToolbarPluginsLabel2"..i, "toolbarPluginsLabel2"..i, pluginObject.__author)
                 bframe ["toolbarPluginsLabel2"..i]:SetPoint ("topleft", anchorFrame, "topleft", 180, y-4)
                 bframe ["toolbarPluginsLabel2"..i].color = notInstalledColor
                 
-                DF:NewLabel (bframe, _, "$parentToolbarPluginsLabel3"..i, "toolbarPluginsLabel3"..i, pluginObject.__version)
+                DF:NewLabel (bframe, nil, "$parentToolbarPluginsLabel3"..i, "toolbarPluginsLabel3"..i, pluginObject.__version)
                 bframe ["toolbarPluginsLabel3"..i]:SetPoint ("topleft", anchorFrame, "topleft", 290, y-4)
                 bframe ["toolbarPluginsLabel3"..i].color = notInstalledColor
     
@@ -3301,7 +3301,7 @@ do
         y = y - 10
     
         -- solo
-        DF:NewLabel (anchorFrame, _, "$parentSoloPluginsLabel", "soloLabel", Loc ["STRING_OPTIONS_PLUGINS_SOLO_ANCHOR"], "GameFontNormal", 16)
+        DF:NewLabel (anchorFrame, nil, "$parentSoloPluginsLabel", "soloLabel", Loc ["STRING_OPTIONS_PLUGINS_SOLO_ANCHOR"], "GameFontNormal", 16)
         anchorFrame.soloLabel:SetPoint ("topleft", anchorFrame, "topleft", 10, y)
         
         y = y - 30
@@ -3311,15 +3311,15 @@ do
             descbar:SetTexture (.3, .3, .3, .8)
             descbar:SetPoint ("topleft", anchorFrame, "topleft", 5, y+3)
             descbar:SetSize (650, 20)
-            DF:NewLabel (anchorFrame, _, "$parentDescNameLabel3", "descNameLabel", Loc ["STRING_OPTIONS_PLUGINS_NAME"], "GameFontNormal", 12)
+            DF:NewLabel (anchorFrame, nil, "$parentDescNameLabel3", "descNameLabel", Loc ["STRING_OPTIONS_PLUGINS_NAME"], "GameFontNormal", 12)
             anchorFrame.descNameLabel:SetPoint ("topleft", anchorFrame, "topleft", 15, y)
-            DF:NewLabel (anchorFrame, _, "$parentDescAuthorLabel3", "descAuthorLabel", Loc ["STRING_OPTIONS_PLUGINS_AUTHOR"], "GameFontNormal", 12)
+            DF:NewLabel (anchorFrame, nil, "$parentDescAuthorLabel3", "descAuthorLabel", Loc ["STRING_OPTIONS_PLUGINS_AUTHOR"], "GameFontNormal", 12)
             anchorFrame.descAuthorLabel:SetPoint ("topleft", anchorFrame, "topleft", 180, y)
-            DF:NewLabel (anchorFrame, _, "$parentDescVersionLabel3", "descVersionLabel", Loc ["STRING_OPTIONS_PLUGINS_VERSION"], "GameFontNormal", 12)
+            DF:NewLabel (anchorFrame, nil, "$parentDescVersionLabel3", "descVersionLabel", Loc ["STRING_OPTIONS_PLUGINS_VERSION"], "GameFontNormal", 12)
             anchorFrame.descVersionLabel:SetPoint ("topleft", anchorFrame, "topleft", 290, y)
-            DF:NewLabel (anchorFrame, _, "$parentDescEnabledLabel3", "descEnabledLabel", Loc ["STRING_ENABLED"], "GameFontNormal", 12)
+            DF:NewLabel (anchorFrame, nil, "$parentDescEnabledLabel3", "descEnabledLabel", Loc ["STRING_ENABLED"], "GameFontNormal", 12)
             anchorFrame.descEnabledLabel:SetPoint ("topleft", anchorFrame, "topleft", 400, y)
-            DF:NewLabel (anchorFrame, _, "$parentDescOptionsLabel3", "descOptionsLabel", Loc ["STRING_OPTIONS_PLUGINS_OPTIONS"], "GameFontNormal", 12)
+            DF:NewLabel (anchorFrame, nil, "$parentDescOptionsLabel3", "descOptionsLabel", Loc ["STRING_OPTIONS_PLUGINS_OPTIONS"], "GameFontNormal", 12)
             anchorFrame.descOptionsLabel:SetPoint ("topleft", anchorFrame, "topleft", 510, y)
         end
         
@@ -3342,18 +3342,18 @@ do
             DF:NewImage (bframe, pluginObject.__icon, 18, 18, nil, nil, "soloPluginsIcon"..i, "$parentSoloPluginsIcon"..i)
             bframe ["soloPluginsIcon"..i]:SetPoint ("topleft", anchorFrame, "topleft", 10, y)
         
-            DF:NewLabel (bframe, _, "$parentSoloPluginsLabel"..i, "soloPluginsLabel"..i, pluginObject.__name)
+            DF:NewLabel (bframe, nil, "$parentSoloPluginsLabel"..i, "soloPluginsLabel"..i, pluginObject.__name)
             bframe ["soloPluginsLabel"..i]:SetPoint ("left", bframe ["soloPluginsIcon"..i], "right", 2, 0)
             
-            DF:NewLabel (bframe, _, "$parentSoloPluginsLabel2"..i, "soloPluginsLabel2"..i, pluginObject.__author)
+            DF:NewLabel (bframe, nil, "$parentSoloPluginsLabel2"..i, "soloPluginsLabel2"..i, pluginObject.__author)
             bframe ["soloPluginsLabel2"..i]:SetPoint ("topleft", anchorFrame, "topleft", 180, y-4)
             
-            DF:NewLabel (bframe, _, "$parentSoloPluginsLabel3"..i, "soloPluginsLabel3"..i, pluginObject.__version)
+            DF:NewLabel (bframe, nil, "$parentSoloPluginsLabel3"..i, "soloPluginsLabel3"..i, pluginObject.__version)
             bframe ["soloPluginsLabel3"..i]:SetPoint ("topleft", anchorFrame, "topleft", 290, y-4)
             
             local plugin_stable = _detalhes:GetPluginSavedTable (absName)
             local plugin = _detalhes:GetPlugin (absName)
-            DF:NewSwitch (bframe, _, "$parentSoloSlider"..i, "soloPluginsSlider"..i, 60, 20, _, _, plugin_stable.enabled, nil, nil, nil, nil, options_switch_template)
+            DF:NewSwitch (bframe, nil, "$parentSoloSlider"..i, "soloPluginsSlider"..i, 60, 20, nil, nil, plugin_stable.enabled, nil, nil, nil, nil, options_switch_template)
             tinsert (anchorFrame.plugin_widgets, bframe ["soloPluginsSlider"..i])
             bframe ["soloPluginsSlider"..i].PluginName = absName
             bframe ["soloPluginsSlider"..i]:SetPoint ("topleft", anchorFrame, "topleft", 415, y+1)
@@ -4452,7 +4452,7 @@ do
                         _detalhes:OpenOptionsWindow (instance)
                         sectionFrame:UpdateWallpaperInfo()
                     end
-                    local okey = DF:NewButton (f, _, "$parentOkeyButton", nil, 105, 20, okey_func, nil, nil, nil, Loc ["STRING_OPTIONS_WALLPAPER_LOAD_OKEY"], 1, options_button_template)
+                    local okey = DF:NewButton (f, nil, "$parentOkeyButton", nil, 105, 20, okey_func, nil, nil, nil, Loc ["STRING_OPTIONS_WALLPAPER_LOAD_OKEY"], 1, options_button_template)
                     okey:SetPoint ("left", editbox.widget, "right", 2, 0)
                     
                     local throubleshoot_func = function() 
@@ -4462,7 +4462,7 @@ do
                             _G.DetailsLoadWallpaperImage.t:SetText (Loc ["STRING_OPTIONS_WALLPAPER_LOAD_EXCLAMATION"])
                         end
                     end
-                    local throubleshoot = DF:NewButton (f, _, "$parentThroubleshootButton", nil, 105, 20, throubleshoot_func, nil, nil, nil, Loc ["STRING_OPTIONS_WALLPAPER_LOAD_TROUBLESHOOT"], 1, options_button_template)
+                    local throubleshoot = DF:NewButton (f, nil, "$parentThroubleshootButton", nil, 105, 20, throubleshoot_func, nil, nil, nil, Loc ["STRING_OPTIONS_WALLPAPER_LOAD_TROUBLESHOOT"], 1, options_button_template)
                     throubleshoot:SetPoint ("left", okey, "right", 2, 0)
                     --throubleshoot:InstallCustomTexture()
                 end
@@ -4885,11 +4885,11 @@ do
         local right_start_at = 450
 
 		--anchor
-		DF:NewLabel (sectionFrame, _, "$parentHideInCombatAnchor", "hideInCombatAnchor", Loc ["STRING_OPTIONS_ALPHAMOD_ANCHOR"], "GameFontNormal")
+		DF:NewLabel (sectionFrame, nil, "$parentHideInCombatAnchor", "hideInCombatAnchor", Loc ["STRING_OPTIONS_ALPHAMOD_ANCHOR"], "GameFontNormal")
 		sectionFrame.hideInCombatAnchor:SetPoint("topleft", sectionFrame, "topleft", right_start_at, startY - 20)
 		
 		--> hide in combat
-		DF:NewLabel (sectionFrame, _, "$parentCombatAlphaLabel", "combatAlphaLabel", Loc ["STRING_OPTIONS_COMBAT_ALPHA"], "GameFontHighlightLeft")
+		DF:NewLabel (sectionFrame, nil, "$parentCombatAlphaLabel", "combatAlphaLabel", Loc ["STRING_OPTIONS_COMBAT_ALPHA"], "GameFontHighlightLeft")
 		
 		local texCoords = {.9, 0.1, 0.1, .9}
 		local typeCombatAlpha = {
@@ -5446,10 +5446,10 @@ do
 
         --> streamer plugin - a.k.a. player spell tracker 
 			--> title anchor
-            DF:NewLabel (sectionFrame, _, "$parentStreamerPluginAnchor", "streamerPluginAnchor", "Action Tracker", "GameFontNormal")
+            DF:NewLabel (sectionFrame, nil, "$parentStreamerPluginAnchor", "streamerPluginAnchor", "Action Tracker", "GameFontNormal")
             sectionFrame.streamerPluginAnchor:SetPoint("topleft", sectionFrame, "topleft", startX, startY - 20)
 
-			local streamerTitleDesc = DF:NewLabel (sectionFrame, _, "$parentStreamerTitleDescText", "StreamerTitleDescTextLabel", "Show the spells you are casting, allowing the viewer to follow your decision making and learn your rotation.", "GameFontNormal", 10, "white")
+			local streamerTitleDesc = DF:NewLabel (sectionFrame, nil, "$parentStreamerTitleDescText", "StreamerTitleDescTextLabel", "Show the spells you are casting, allowing the viewer to follow your decision making and learn your rotation.", "GameFontNormal", 10, "white")
 			streamerTitleDesc:SetSize (270, 40)
 			streamerTitleDesc:SetJustifyV ("top")
 			streamerTitleDesc:SetPoint ("topleft", sectionFrame.streamerPluginAnchor, "bottomleft", 0, -4)
@@ -5473,12 +5473,12 @@ do
 								_G.DetailsOptionsWindow:Hide()
 							end)
 						end
-						local configurePluginButton = DF:NewButton (sectionFrame, _, "$parentConfigureStreamerPluginButton", "configureStreamerPlugin", 100, 20, configure_streamer_plugin, nil, nil, nil, "Action Tracker Options", nil, options_button_template)
+						local configurePluginButton = DF:NewButton (sectionFrame, nil, "$parentConfigureStreamerPluginButton", "configureStreamerPlugin", 100, 20, configure_streamer_plugin, nil, nil, nil, "Action Tracker Options", nil, options_button_template)
 						configurePluginButton:SetWidth (button_width)
 						configurePluginButton:SetPoint ("topleft", streamerTitleImage, "bottomleft", 0, -7)
 						
 						--> text telling how to disable
-						local pluginAlreadyEnabled = DF:NewLabel (sectionFrame, _, "$parentStreamerAlreadyEnabledText", "StreamerAlreadyEnabledTextLabel", "Plugin is enabled. You may disable it on Plugin Management section.", "GameFontNormal", 10, "white")
+						local pluginAlreadyEnabled = DF:NewLabel (sectionFrame, nil, "$parentStreamerAlreadyEnabledText", "StreamerAlreadyEnabledTextLabel", "Plugin is enabled. You may disable it on Plugin Management section.", "GameFontNormal", 10, "white")
 						pluginAlreadyEnabled:SetJustifyV ("top")
 						pluginAlreadyEnabled:SetSize (270, 40)
 						pluginAlreadyEnabled:SetPoint ("topleft", configurePluginButton, "bottomleft", 0, -7)
@@ -5495,35 +5495,35 @@ do
 							local configure_streamer_plugin = function()
 								StreamerPlugin.OpenOptionsPanel()
 							end
-							local configurePluginButton = DF:NewButton (sectionFrame, _, "$parentConfigureStreamerPluginButton", "configureStreamerPlugin", 100, 20, configure_streamer_plugin, nil, nil, nil, "Action Tracker Options", nil, options_button_template)
+							local configurePluginButton = DF:NewButton (sectionFrame, nil, "$parentConfigureStreamerPluginButton", "configureStreamerPlugin", 100, 20, configure_streamer_plugin, nil, nil, nil, "Action Tracker Options", nil, options_button_template)
 							configurePluginButton:SetWidth (button_width)
 							configurePluginButton:SetPoint ("topleft", streamerTitleImage, "bottomleft", 0, -7)
 							
 							--> text telling how to disable
-							local pluginAlreadyEnabled = DF:NewLabel (sectionFrame, _, "$parentStreamerAlreadyEnabledText", "StreamerAlreadyEnabledTextLabel", "Plugin is enabled. You may disable it on Plugin Management section.", "GameFontNormal", 10, "white")
+							local pluginAlreadyEnabled = DF:NewLabel (sectionFrame, nil, "$parentStreamerAlreadyEnabledText", "StreamerAlreadyEnabledTextLabel", "Plugin is enabled. You may disable it on Plugin Management section.", "GameFontNormal", 10, "white")
 							pluginAlreadyEnabled:SetJustifyV ("top")
 							pluginAlreadyEnabled:SetSize (270, 40)
 							pluginAlreadyEnabled:SetPoint ("topleft", configurePluginButton, "bottomleft", 0, -7)
 						end
 						
-						local enablePluginButton = DF:NewButton (sectionFrame, _, "$parentEnableStreamerPluginButton", "enableStreamerPluginButton", 100, 20, enable_streamer_plugin, nil, nil, nil, "Enable Plugin", nil, options_button_template)
+						local enablePluginButton = DF:NewButton (sectionFrame, nil, "$parentEnableStreamerPluginButton", "enableStreamerPluginButton", 100, 20, enable_streamer_plugin, nil, nil, nil, "Enable Plugin", nil, options_button_template)
 						enablePluginButton:SetWidth (button_width)
 						enablePluginButton:SetPoint ("topleft", streamerTitleImage, "bottomleft", 0, -5)
 					end
 				end
 			else
 				--> plugin is disabled at the addon control panel
-				local pluginDisabled = DF:NewLabel (sectionFrame, _, "$parentStreamerDisabledText", "StreamerDisabledTextLabel", "Details!: Streamer Plugin is disabled on the AddOns Control Panel.", "GameFontNormal", 10, "red")
+				local pluginDisabled = DF:NewLabel (sectionFrame, nil, "$parentStreamerDisabledText", "StreamerDisabledTextLabel", "Details!: Streamer Plugin is disabled on the AddOns Control Panel.", "GameFontNormal", 10, "red")
 				pluginDisabled:SetSize (270, 40)
 				pluginDisabled:SetPoint ("topleft", streamerTitleImage, "bottomleft", 0, -2)
 			end
 		
 		
 		--> event tracker
-            DF:NewLabel (sectionFrame, _, "$parentEventTrackerAnchor", "eventTrackerAnchor", "Event Tracker", "GameFontNormal")
+            DF:NewLabel (sectionFrame, nil, "$parentEventTrackerAnchor", "eventTrackerAnchor", "Event Tracker", "GameFontNormal")
             sectionFrame.eventTrackerAnchor:SetPoint("topleft", sectionFrame, "topleft", startX, startY - 180)
 
-			local eventTrackerTitleDesc = DF:NewLabel (sectionFrame, _, "$parentEventTrackerTitleDescText", "EventTrackerTitleDescTextLabel", "Show what's happening near you so the viewer can follow what's going on. Show cooldowns, CC, spell interruption. Useful on any group content.", "GameFontNormal", 10, "white")
+			local eventTrackerTitleDesc = DF:NewLabel (sectionFrame, nil, "$parentEventTrackerTitleDescText", "EventTrackerTitleDescTextLabel", "Show what's happening near you so the viewer can follow what's going on. Show cooldowns, CC, spell interruption. Useful on any group content.", "GameFontNormal", 10, "white")
 			eventTrackerTitleDesc:SetJustifyV ("top")
 			eventTrackerTitleDesc:SetSize (270, 40)
 			eventTrackerTitleDesc:SetPoint ("topleft", sectionFrame.eventTrackerAnchor, "bottomleft", 0, -4)
@@ -5532,8 +5532,8 @@ do
 			eventTrackerTitleImage:SetPoint ("topleft", sectionFrame.eventTrackerAnchor, "bottomleft", 0, -40)
 			
 			--> enable feature checkbox
-				DF:NewLabel (sectionFrame, _, "$parentEnableEventTrackerLabel", "EventTrackerLabel", "Enable Event Tracker", "GameFontHighlightLeft")
-				DF:NewSwitch (sectionFrame, _, "$parentEventTrackerSlider", "EventTrackerSlider", 60, 20, _, _, _detalhes.event_tracker.enabled, nil, nil, nil, nil, options_switch_template)
+				DF:NewLabel (sectionFrame, nil, "$parentEnableEventTrackerLabel", "EventTrackerLabel", "Enable Event Tracker", "GameFontHighlightLeft")
+				DF:NewSwitch (sectionFrame, nil, "$parentEventTrackerSlider", "EventTrackerSlider", 60, 20, nil, nil, _detalhes.event_tracker.enabled, nil, nil, nil, nil, options_switch_template)
 
 				sectionFrame.EventTrackerSlider:SetPoint ("left", sectionFrame.EventTrackerLabel, "right", 2)
 				sectionFrame.EventTrackerSlider:SetAsCheckBox()
@@ -5552,16 +5552,16 @@ do
 						_G.DetailsOptionsWindow:Hide()
 					end)
 				end
-				local configureEventTrackerButton = DF:NewButton (sectionFrame, _, "$parentConfigureEventTrackerButton", "configureEventTracker", 100, 20, configure_event_tracker, nil, nil, nil, "Event Tracker Options", nil, options_button_template)
+				local configureEventTrackerButton = DF:NewButton (sectionFrame, nil, "$parentConfigureEventTrackerButton", "configureEventTracker", 100, 20, configure_event_tracker, nil, nil, nil, "Event Tracker Options", nil, options_button_template)
 				configureEventTrackerButton:SetWidth (button_width)
 				configureEventTrackerButton:SetPoint ("topleft", sectionFrame.EventTrackerLabel, "bottomleft", 0, -7)
 
 
 		--> current dps
-            DF:NewLabel (sectionFrame, _, "$parentCurrentDPSAnchor", "currentDPSAnchor", "The Real Current DPS", "GameFontNormal")
+            DF:NewLabel (sectionFrame, nil, "$parentCurrentDPSAnchor", "currentDPSAnchor", "The Real Current DPS", "GameFontNormal")
             sectionFrame.currentDPSAnchor:SetPoint("topleft", sectionFrame, "topleft", startX + 350, startY - 20)
 
-			local currentDPSTitleDesc = DF:NewLabel (sectionFrame, _, "$parentCurrentDPSTitleDescText", "CurrentDPSTitleDescTextLabel", "Show a frame with DPS done only in the last 5 seconds. Useful for arena matches and mythic dungeons.", "GameFontNormal", 10, "white")
+			local currentDPSTitleDesc = DF:NewLabel (sectionFrame, nil, "$parentCurrentDPSTitleDescText", "CurrentDPSTitleDescTextLabel", "Show a frame with DPS done only in the last 5 seconds. Useful for arena matches and mythic dungeons.", "GameFontNormal", 10, "white")
 			currentDPSTitleDesc:SetJustifyV ("top")
 			currentDPSTitleDesc:SetSize (270, 40)
 			currentDPSTitleDesc:SetPoint ("topleft", sectionFrame.currentDPSAnchor, "bottomleft", 0, -4)
@@ -5570,8 +5570,8 @@ do
 			currentDPSTitleImage:SetPoint ("topleft", sectionFrame.currentDPSAnchor, "bottomleft", 0, -40)
 			
 			--> enable feature checkbox
-				DF:NewLabel (sectionFrame, _, "$parentEnableCurrentDPSLabel", "CurrentDPSLabel", "Enable The Real Current Dps", "GameFontHighlightLeft")
-				DF:NewSwitch (sectionFrame, _, "$parentCurrentDPSSlider", "CurrentDPSSlider", 60, 20, _, _, _detalhes.current_dps_meter.enabled, nil, nil, nil, nil, options_switch_template)
+				DF:NewLabel (sectionFrame, nil, "$parentEnableCurrentDPSLabel", "CurrentDPSLabel", "Enable The Real Current Dps", "GameFontHighlightLeft")
+				DF:NewSwitch (sectionFrame, nil, "$parentCurrentDPSSlider", "CurrentDPSSlider", 60, 20, nil, nil, _detalhes.current_dps_meter.enabled, nil, nil, nil, nil, options_switch_template)
 
 				sectionFrame.CurrentDPSSlider:SetPoint ("left", sectionFrame.CurrentDPSLabel, "right", 2)
 				sectionFrame.CurrentDPSSlider:SetAsCheckBox()
@@ -5591,7 +5591,7 @@ do
 						_G.DetailsOptionsWindow:Hide()
 					end)
 				end
-				local configureCurrentDPSButton = DF:NewButton (sectionFrame, _, "$parentConfigureCurrentDPSButton", "configureCurrentDPS", 100, 20, configure_current_dps, nil, nil, nil, "Current Real DPS Options", nil, options_button_template)
+				local configureCurrentDPSButton = DF:NewButton (sectionFrame, nil, "$parentConfigureCurrentDPSButton", "configureCurrentDPS", 100, 20, configure_current_dps, nil, nil, nil, "Current Real DPS Options", nil, options_button_template)
 				configureCurrentDPSButton:SetWidth (button_width)
 				configureCurrentDPSButton:SetPoint ("topleft", sectionFrame.CurrentDPSLabel, "bottomleft", 0, -7)
 
@@ -5813,8 +5813,8 @@ do
 		panel:SetPoint (startX, startY - 40)
 		
 	--> consilidade spells
-		DF:NewLabel (sectionFrame, _, "$parentConsolidadeSpellsLabel", "ConsolidadeSpellsLabel", Loc ["STRING_OPTIONSMENU_SPELLS_CONSOLIDATE"], "GameFontHighlightLeft")
-		DF:NewSwitch (sectionFrame, _, "$parentConsolidadeSpellsSwitch", "ConsolidadeSpellsSwitch", 60, 20, nil, nil, _detalhes.override_spellids, nil, nil, nil, nil, options_switch_template)
+		DF:NewLabel (sectionFrame, nil, "$parentConsolidadeSpellsLabel", "ConsolidadeSpellsLabel", Loc ["STRING_OPTIONSMENU_SPELLS_CONSOLIDATE"], "GameFontHighlightLeft")
+		DF:NewSwitch (sectionFrame, nil, "$parentConsolidadeSpellsSwitch", "ConsolidadeSpellsSwitch", 60, 20, nil, nil, _detalhes.override_spellids, nil, nil, nil, nil, options_switch_template)
 		sectionFrame.ConsolidadeSpellsLabel:SetPoint ("left", sectionFrame.ConsolidadeSpellsSwitch, "right", 3)
 		sectionFrame.ConsolidadeSpellsSwitch:SetAsCheckBox()
 		sectionFrame.ConsolidadeSpellsSwitch.OnSwitch = function (self, instance, value)
@@ -5841,13 +5841,13 @@ do
     local buildSection = function(sectionFrame)
 
 	--> title
-    local titulo_datacharts = DF:NewLabel (sectionFrame, _, "$parentTituloDataChartsText", "DataChartsLabel", Loc ["STRING_OPTIONS_DATACHARTTITLE"], "GameFontNormal", 16)
-    local titulo_datacharts_desc = DF:NewLabel (sectionFrame, _, "$parentDataChartsText2", "DataCharts2Label", Loc ["STRING_OPTIONS_DATACHARTTITLE_DESC"], "GameFontNormal", 10, "white")
+    local titulo_datacharts = DF:NewLabel (sectionFrame, nil, "$parentTituloDataChartsText", "DataChartsLabel", Loc ["STRING_OPTIONS_DATACHARTTITLE"], "GameFontNormal", 16)
+    local titulo_datacharts_desc = DF:NewLabel (sectionFrame, nil, "$parentDataChartsText2", "DataCharts2Label", Loc ["STRING_OPTIONS_DATACHARTTITLE_DESC"], "GameFontNormal", 10, "white")
     titulo_datacharts_desc.width = 350
 
 --> warning
     if (not _detalhes:GetPlugin ("DETAILS_PLUGIN_CHART_VIEWER")) then
-        local label = DF:NewLabel (sectionFrame, _, "$parentPluginWarningLabel", "PluginWarningLabel", Loc ["STRING_OPTIONS_CHART_PLUGINWARNING"], "GameFontNormal")
+        local label = DF:NewLabel (sectionFrame, nil, "$parentPluginWarningLabel", "PluginWarningLabel", Loc ["STRING_OPTIONS_CHART_PLUGINWARNING"], "GameFontNormal")
         local image = DF:NewImage (sectionFrame, [[Interface\DialogFrame\UI-Dialog-Icon-AlertNew]])
         label:SetPoint ("topright", sectionFrame, "topright", -42, -10)
         label:SetJustifyH ("left")

--- a/frames/window_playerbreakdown.lua
+++ b/frames/window_playerbreakdown.lua
@@ -100,7 +100,7 @@ function _detalhes:AbreJanelaInfo (jogador, from_att_change, refresh, ShiftKeyDo
 			_detalhes:FechaJanelaInfo()
 			return
 		end
-		return _detalhes.row_singleclick_overwrite [self.atributo][self.sub_atributo] (_, jogador, self, ShiftKeyDown, ControlKeyDown)
+		return _detalhes.row_singleclick_overwrite [self.atributo][self.sub_atributo] (nil, jogador, self, ShiftKeyDown, ControlKeyDown)
 	end
 	
 	if (self.modo == _detalhes._detalhes_props["MODO_RAID"]) then
@@ -5639,7 +5639,7 @@ local target_on_enter = function (self)
 						local spellId = target[1]
 						local damageDone = target[2]
 						local spellName, _, spellIcon = _GetSpellInfo(spellId)
-						GameCooltip:AddLine(spellName, SelectedToKFunction (_, damageDone) .. " (" .. floor(damageDone / topDamage * 100) .. "%)")
+						GameCooltip:AddLine(spellName, SelectedToKFunction (nil, damageDone) .. " (" .. floor(damageDone / topDamage * 100) .. "%)")
 						GameCooltip:AddIcon(spellIcon, 1, 1, 16, 16, .1, .9, .1, .9)
 						_detalhes:AddTooltipBackgroundStatusbar (false, damageDone / topDamage * 100)
 					end
@@ -5660,13 +5660,13 @@ local target_on_enter = function (self)
 							if (info.target_persecond) then
 								GameTooltip:AddDoubleLine (index .. ". |TInterface\\AddOns\\Details\\images\\classes_small_alpha:14:14:0:0:128:128:"..cords[1]*128 ..":"..cords[2]*128 ..":"..cords[3]*128 ..":"..cords[4]*128 .."|t " .. target [1], _detalhes:comma_value ( _math_floor (target [2] / meu_tempo) ), 1, 1, 1, 1, 1, 1)
 							else
-								GameTooltip:AddDoubleLine (index .. ". |TInterface\\AddOns\\Details\\images\\classes_small_alpha:14:14:0:0:128:128:"..cords[1]*128 ..":"..cords[2]*128 ..":"..cords[3]*128 ..":"..cords[4]*128 .."|t " .. target [1], SelectedToKFunction (_, target [2]), 1, 1, 1, 1, 1, 1)
+								GameTooltip:AddDoubleLine (index .. ". |TInterface\\AddOns\\Details\\images\\classes_small_alpha:14:14:0:0:128:128:"..cords[1]*128 ..":"..cords[2]*128 ..":"..cords[3]*128 ..":"..cords[4]*128 .."|t " .. target [1], SelectedToKFunction (nil, target [2]), 1, 1, 1, 1, 1, 1)
 							end
 						else
 							if (info.target_persecond) then
 								GameTooltip:AddDoubleLine (index .. ". " .. target [1], _detalhes:comma_value ( _math_floor (target [2] / meu_tempo)), 1, 1, 1, 1, 1, 1)
 							else
-								GameTooltip:AddDoubleLine (index .. ". " .. target [1], SelectedToKFunction (_, target [2]), 1, 1, 1, 1, 1, 1)
+								GameTooltip:AddDoubleLine (index .. ". " .. target [1], SelectedToKFunction (nil, target [2]), 1, 1, 1, 1, 1, 1)
 							end
 						end
 					end

--- a/frames/window_report.lua
+++ b/frames/window_report.lua
@@ -373,7 +373,7 @@ local function cria_drop_down (este_gump)
 		end
 		este_gump.dropdown_func = build_list
 	
-		local select_output = gump:NewDropDown (este_gump, _, "$parentOutputDropdown", "select", 185, 20, build_list, 1)
+		local select_output = gump:NewDropDown (este_gump, nil, "$parentOutputDropdown", "select", 185, 20, build_list, 1)
 		select_output:SetPoint ("topleft", este_gump, "topleft", 107, -55)
 		este_gump.select = select_output.widget
 		este_gump.dropdown = select_output
@@ -989,7 +989,7 @@ local function cria_drop_down (este_gump)
 			
 			local recently_on_click = function (self)
 				if (self.index) then
-					return _detalhes.ReportFromLatest (_, _, self.index)
+					return _detalhes.ReportFromLatest (nil, nil, self.index)
 				end 
 			end
 			

--- a/frames/window_runcode.lua
+++ b/frames/window_runcode.lua
@@ -119,7 +119,7 @@ function Details.OpenRunCodeWindow()
         end
         
         local code_type_label = DF:CreateLabel (f, "Event:", DF:GetTemplate ("font", "ORANGE_FONT_TEMPLATE"))
-        local code_type_dropdown = DF:CreateDropDown (f, build_CodeType_dropdown_options, 1, 160, 20, "CodeTypeDropdown", _, DF:GetTemplate ("dropdown", "OPTIONS_DROPDOWN_TEMPLATE"))
+        local code_type_dropdown = DF:CreateDropDown (f, build_CodeType_dropdown_options, 1, 160, 20, "CodeTypeDropdown", nil, DF:GetTemplate ("dropdown", "OPTIONS_DROPDOWN_TEMPLATE"))
         code_type_dropdown:SetPoint ("left", code_type_label, "right", 2, 0)
         code_type_dropdown:SetFrameLevel (code_editor:GetFrameLevel() + 10)
         code_type_label:SetPoint ("bottomleft", code_editor, "topleft", 0, 8)

--- a/frames/window_scrolldamage.lua
+++ b/frames/window_scrolldamage.lua
@@ -87,7 +87,7 @@ function Details:ScrollDamage()
 						line.Icon:SetTexture(spellIcon)
 						line.Icon:SetTexCoord(.1, .9, .1, .9)
 						
-						line.DamageText.text = isCritical and "|cFFFFFF00" .. ToK (_, amount) or ToK (_, amount)
+						line.DamageText.text = isCritical and "|cFFFFFF00" .. ToK (nil, amount) or ToK (nil, amount)
 						line.TimeText.text = format("%.2f", time - DetailsScrollDamage.Data.Started)
 						--line.TokenText.text = token:gsub ("SPELL_", "")
 						--line.SchoolText.text = _detalhes:GetSpellSchoolFormatedName (school)
@@ -236,7 +236,7 @@ function Details:ScrollDamage()
 		local onToggleAutoOpen = function(_, _, state)
 			Details.damage_scroll_auto_open = state
 		end
-		local autoOpenCheckbox = DetailsFramework:CreateSwitch(statusBar, onToggleAutoOpen, Details.auto_open_news_window, _, _, _, _, "AutoOpenCheckbox", _, _, _, _, _, DetailsFramework:GetTemplate ("switch", "OPTIONS_CHECKBOX_BRIGHT_TEMPLATE"))
+		local autoOpenCheckbox = DetailsFramework:CreateSwitch(statusBar, onToggleAutoOpen, Details.auto_open_news_window, nil, nil, nil, nil, "AutoOpenCheckbox", nil, nil, nil, nil, nil, DetailsFramework:GetTemplate ("switch", "OPTIONS_CHECKBOX_BRIGHT_TEMPLATE"))
 		autoOpenCheckbox:SetAsCheckBox()
 		autoOpenCheckbox:SetPoint("left", statusBar, "left", 5, 0)
 

--- a/frames/window_statistics.lua
+++ b/frames/window_statistics.lua
@@ -382,7 +382,7 @@ function Details:OpenRaidHistoryWindow (_raid, _boss, _difficulty, _role, _guild
             return raid_list
         end
         local raid_dropdown = DF:CreateDropDown (f, build_raid_list, 1, dropdown_size, 20, "select_raid")
-        local raid_string = DF:CreateLabel (f, Loc ["STRING_GUILDDAMAGERANK_RAID"] .. ":", _, _, "GameFontNormal", "select_raid_label")
+        local raid_string = DF:CreateLabel (f, Loc ["STRING_GUILDDAMAGERANK_RAID"] .. ":", nil, nil, "GameFontNormal", "select_raid_label")
         raid_dropdown:SetTemplate (DF:GetTemplate ("dropdown", "OPTIONS_DROPDOWN_TEMPLATE"))
         
         --> select boss:
@@ -393,7 +393,7 @@ function Details:OpenRaidHistoryWindow (_raid, _boss, _difficulty, _role, _guild
             return boss_list
         end
         local boss_dropdown = DF:CreateDropDown (f, build_boss_list, 1, dropdown_size, 20, "select_boss")
-        local boss_string = DF:CreateLabel (f, Loc ["STRING_GUILDDAMAGERANK_BOSS"] .. ":", _, _, "GameFontNormal", "select_boss_label")
+        local boss_string = DF:CreateLabel (f, Loc ["STRING_GUILDDAMAGERANK_BOSS"] .. ":", nil, nil, "GameFontNormal", "select_boss_label")
         boss_dropdown:SetTemplate (DF:GetTemplate ("dropdown", "OPTIONS_DROPDOWN_TEMPLATE"))
 
         --> select difficulty:
@@ -406,7 +406,7 @@ function Details:OpenRaidHistoryWindow (_raid, _boss, _difficulty, _role, _guild
             return diff_list
         end
         local diff_dropdown = DF:CreateDropDown (f, build_diff_list, 1, dropdown_size, 20, "select_diff")
-        local diff_string = DF:CreateLabel (f, Loc ["STRING_GUILDDAMAGERANK_DIFF"] .. ":", _, _, "GameFontNormal", "select_diff_label")
+        local diff_string = DF:CreateLabel (f, Loc ["STRING_GUILDDAMAGERANK_DIFF"] .. ":", nil, nil, "GameFontNormal", "select_diff_label")
         diff_dropdown:SetTemplate (DF:GetTemplate ("dropdown", "OPTIONS_DROPDOWN_TEMPLATE"))
         
         --> select role:
@@ -420,7 +420,7 @@ function Details:OpenRaidHistoryWindow (_raid, _boss, _difficulty, _role, _guild
             }
         end
         local role_dropdown = DF:CreateDropDown (f, build_role_list, 1, dropdown_size, 20, "select_role")
-        local role_string = DF:CreateLabel (f, Loc ["STRING_GUILDDAMAGERANK_ROLE"] .. ":", _, _, "GameFontNormal", "select_role_label")
+        local role_string = DF:CreateLabel (f, Loc ["STRING_GUILDDAMAGERANK_ROLE"] .. ":", nil, nil, "GameFontNormal", "select_role_label")
         role_dropdown:SetTemplate (DF:GetTemplate ("dropdown", "OPTIONS_DROPDOWN_TEMPLATE"))
         
         --> select guild:
@@ -431,7 +431,7 @@ function Details:OpenRaidHistoryWindow (_raid, _boss, _difficulty, _role, _guild
             return guild_list
         end
         local guild_dropdown = DF:CreateDropDown (f, build_guild_list, 1, dropdown_size, 20, "select_guild")
-        local guild_string = DF:CreateLabel (f, Loc ["STRING_GUILDDAMAGERANK_GUILD"] .. ":", _, _, "GameFontNormal", "select_guild_label")
+        local guild_string = DF:CreateLabel (f, Loc ["STRING_GUILDDAMAGERANK_GUILD"] .. ":", nil, nil, "GameFontNormal", "select_guild_label")
         guild_dropdown:SetTemplate (DF:GetTemplate ("dropdown", "OPTIONS_DROPDOWN_TEMPLATE"))
         
         --> select playerbase:
@@ -445,7 +445,7 @@ function Details:OpenRaidHistoryWindow (_raid, _boss, _difficulty, _role, _guild
             }
         end
         local player_dropdown = DF:CreateDropDown (f, build_player_list, 1, dropdown_size, 20, "select_player")
-        local player_string = DF:CreateLabel (f, Loc ["STRING_GUILDDAMAGERANK_PLAYERBASE"] .. ":", _, _, "GameFontNormal", "select_player_label")
+        local player_string = DF:CreateLabel (f, Loc ["STRING_GUILDDAMAGERANK_PLAYERBASE"] .. ":", nil, nil, "GameFontNormal", "select_player_label")
         player_dropdown:SetTemplate (DF:GetTemplate ("dropdown", "OPTIONS_DROPDOWN_TEMPLATE"))
 
         --> select player:
@@ -476,7 +476,7 @@ function Details:OpenRaidHistoryWindow (_raid, _boss, _difficulty, _role, _guild
             return t
         end
         local player2_dropdown = DF:CreateDropDown (f, build_player2_list, 1, dropdown_size, 20, "select_player2")
-        local player2_string = DF:CreateLabel (f, Loc ["STRING_GUILDDAMAGERANK_PLAYERBASE_PLAYER"] .. ":", _, _, "GameFontNormal", "select_player2_label")
+        local player2_string = DF:CreateLabel (f, Loc ["STRING_GUILDDAMAGERANK_PLAYERBASE_PLAYER"] .. ":", nil, nil, "GameFontNormal", "select_player2_label")
         player2_dropdown:SetTemplate (DF:GetTemplate ("dropdown", "OPTIONS_DROPDOWN_TEMPLATE"))
         
         function f:UpdateDropdowns (DoNotSelectRaid)
@@ -525,7 +525,7 @@ function Details:OpenRaidHistoryWindow (_raid, _boss, _difficulty, _role, _guild
 
                     for encounterId, encounterTable in pairs (encounterIdTable) do 
                         if (not boss_repeated [encounterId]) then
-                            local encounter, instance = Details:GetBossEncounterDetailsFromEncounterId (_, encounterId)
+                            local encounter, instance = Details:GetBossEncounterDetailsFromEncounterId (nil, encounterId)
                             if (encounter) then
                                 local InstanceID = Details:GetInstanceIdFromEncounterId (encounterId)
                                 if (raidSelected == InstanceID) then
@@ -621,7 +621,7 @@ function Details:OpenRaidHistoryWindow (_raid, _boss, _difficulty, _role, _guild
 
                     for encounterId, encounterTable in pairs (encounterIdTable) do 
                         if (not boss_repeated [encounterId]) then
-                            local encounter, instance = Details:GetBossEncounterDetailsFromEncounterId (_, encounterId)
+                            local encounter, instance = Details:GetBossEncounterDetailsFromEncounterId (nil, encounterId)
                             if (encounter) then
                                 local InstanceID = Details:GetInstanceIdFromEncounterId (encounterId)
                                 if (raidSelected == InstanceID) then

--- a/frames/window_switch.lua
+++ b/frames/window_switch.lua
@@ -585,7 +585,7 @@ do
 	end
 	
 	--> limita��o: n�o tenho como pegar o base frame da inst�ncia por aqui
-	frame.close = gump:NewDetailsButton (frame, frame, _, function() end, nil, nil, 1, 1, "", "", "", "", {rightFunc = {func = _detalhes.switch.CloseMe, param1 = nil, param2 = nil}}, "DetailsSwitchPanelClose")
+	frame.close = gump:NewDetailsButton (frame, frame, nil, function() end, nil, nil, 1, 1, "", "", "", "", {rightFunc = {func = _detalhes.switch.CloseMe, param1 = nil, param2 = nil}}, "DetailsSwitchPanelClose")
 	frame.close:SetPoint ("topleft", frame, "topleft")
 	frame.close:SetPoint ("bottomright", frame, "bottomright")
 	frame.close:SetFrameLevel (9)

--- a/frames/window_welcome.lua
+++ b/frames/window_welcome.lua
@@ -273,7 +273,7 @@ local window_openned_at = time()
 		texto555:SetText (Loc ["STRING_WELCOME_45"])
 		texto555:SetTextColor (1, 1, 1, 1)
 		
-		local changemind = g:NewLabel (window, _, "$parentChangeMind55Label", "changemind55Label", Loc ["STRING_WELCOME_2"], "GameFontNormal", 9, "orange")
+		local changemind = g:NewLabel (window, nil, "$parentChangeMind55Label", "changemind55Label", Loc ["STRING_WELCOME_2"], "GameFontNormal", 9, "orange")
 		window.changemind55Label:SetPoint ("center", window, "center")
 		window.changemind55Label:SetPoint ("bottom", window, "bottom", 0, 19)
 		window.changemind55Label.align = "|"
@@ -319,11 +319,11 @@ local window_openned_at = time()
 			end
 			
 			local instance1 = _detalhes:GetInstance (1)
-			local skin_dropdown = g:NewDropDown (window, _, "$parentSkinDropdown", "skinDropdown", 160, 20, buildSkinMenu, instance1.skin)
+			local skin_dropdown = g:NewDropDown (window, nil, "$parentSkinDropdown", "skinDropdown", 160, 20, buildSkinMenu, instance1.skin)
 			skin_dropdown:SetTemplate (g:GetTemplate ("dropdown", "OPTIONS_DROPDOWN_TEMPLATE"))
 			skin_dropdown.tooltip = Loc ["STRING_WELCOME_58"]
 			
-			local skin_label = g:NewLabel (window, _, "$parentSkinLabel", "skinLabel", Loc ["STRING_OPTIONS_INSTANCE_SKIN"] .. ":", "GameFontNormal")
+			local skin_label = g:NewLabel (window, nil, "$parentSkinLabel", "skinLabel", Loc ["STRING_OPTIONS_INSTANCE_SKIN"] .. ":", "GameFontNormal")
 			skin_dropdown:SetPoint ("left", skin_label, "right", 2)
 			skin_label:SetPoint ("topleft", window, "topleft", 30, -133)
 
@@ -422,8 +422,8 @@ local window_openned_at = time()
 			end
 		
 			--Latin Alphabet
-			g:NewLabel (window, _, "$parentLatinAlphabetLabel", "LatinAlphabetLabel", Loc["STRING_WELCOME_74"], "GameFontHighlightLeft")
-			g:NewSwitch (window, _, "$parentLatinAlphabetCheckBox", "LatinAlphabetCheckBox", 20, 20, _, _, true)
+			g:NewLabel (window, nil, "$parentLatinAlphabetLabel", "LatinAlphabetLabel", Loc["STRING_WELCOME_74"], "GameFontHighlightLeft")
+			g:NewSwitch (window, nil, "$parentLatinAlphabetCheckBox", "LatinAlphabetCheckBox", 20, 20, nil, nil, true)
 			window.LatinAlphabetCheckBox:SetAsCheckBox()
 			window.LatinAlphabetCheckBox:SetFixedParameter (1)
 			window.LatinAlphabetCheckBox:SetTemplate (g:GetTemplate ("switch", "OPTIONS_CHECKBOX_TEMPLATE"))
@@ -434,8 +434,8 @@ local window_openned_at = time()
 			tinsert (allAlphabetLabels, window.LatinAlphabetLabel)
 			
 			--Russian
-			g:NewLabel (window, _, "$parentCyrillicAlphabetLabel", "CyrillicAlphabetLabel", Loc["STRING_WELCOME_75"], "GameFontHighlightLeft")
-			g:NewSwitch (window, _, "$parentCyrillicAlphabetCheckBox", "CyrillicAlphabetCheckBox", 20, 20, _, _, false)
+			g:NewLabel (window, nil, "$parentCyrillicAlphabetLabel", "CyrillicAlphabetLabel", Loc["STRING_WELCOME_75"], "GameFontHighlightLeft")
+			g:NewSwitch (window, nil, "$parentCyrillicAlphabetCheckBox", "CyrillicAlphabetCheckBox", 20, 20, nil, nil, false)
 			window.CyrillicAlphabetCheckBox:SetAsCheckBox()
 			window.CyrillicAlphabetCheckBox:SetFixedParameter (2)
 			window.CyrillicAlphabetCheckBox:SetTemplate (g:GetTemplate ("switch", "OPTIONS_CHECKBOX_TEMPLATE"))
@@ -445,8 +445,8 @@ local window_openned_at = time()
 			tinsert (allAlphabetLabels, window.CyrillicAlphabetLabel)
 			
 			--Chinese
-			g:NewLabel (window, _, "$parentChinaAlphabetLabel", "ChinaAlphabetLabel", Loc["STRING_WELCOME_76"], "GameFontHighlightLeft")
-			g:NewSwitch (window, _, "$parentChinaCheckBox", "ChinaCheckBox", 20, 20, _, _, false)
+			g:NewLabel (window, nil, "$parentChinaAlphabetLabel", "ChinaAlphabetLabel", Loc["STRING_WELCOME_76"], "GameFontHighlightLeft")
+			g:NewSwitch (window, nil, "$parentChinaCheckBox", "ChinaCheckBox", 20, 20, nil, nil, false)
 			window.ChinaCheckBox:SetAsCheckBox()
 			window.ChinaCheckBox:SetFixedParameter (3)
 			window.ChinaCheckBox:SetTemplate (g:GetTemplate ("switch", "OPTIONS_CHECKBOX_TEMPLATE"))
@@ -456,8 +456,8 @@ local window_openned_at = time()
 			tinsert (allAlphabetLabels, window.ChinaAlphabetLabel)
 			
 			--Korea
-			g:NewLabel (window, _, "$parentKoreanAlphabetLabel", "KoreanAlphabetLabel", Loc["STRING_WELCOME_77"], "GameFontHighlightLeft")
-			g:NewSwitch (window, _, "$parentKoreanCheckBox", "KoreanCheckBox", 20, 20, _, _, false)
+			g:NewLabel (window, nil, "$parentKoreanAlphabetLabel", "KoreanAlphabetLabel", Loc["STRING_WELCOME_77"], "GameFontHighlightLeft")
+			g:NewSwitch (window, nil, "$parentKoreanCheckBox", "KoreanCheckBox", 20, 20, nil, nil, false)
 			window.KoreanCheckBox:SetAsCheckBox()
 			window.KoreanCheckBox:SetFixedParameter (4)
 			window.KoreanCheckBox:SetTemplate (g:GetTemplate ("switch", "OPTIONS_CHECKBOX_TEMPLATE"))
@@ -467,8 +467,8 @@ local window_openned_at = time()
 			tinsert (allAlphabetLabels, window.KoreanAlphabetLabel)
 			
 			--Taiwan
-			g:NewLabel (window, _, "$parentTaiwanAlphabetLabel", "TaiwanAlphabetLabel", Loc["STRING_WELCOME_78"], "GameFontHighlightLeft")
-			g:NewSwitch (window, _, "$parentTaiwanCheckBox", "TaiwanCheckBox", 20, 20, _, _, false)
+			g:NewLabel (window, nil, "$parentTaiwanAlphabetLabel", "TaiwanAlphabetLabel", Loc["STRING_WELCOME_78"], "GameFontHighlightLeft")
+			g:NewSwitch (window, nil, "$parentTaiwanCheckBox", "TaiwanCheckBox", 20, 20, nil, nil, false)
 			window.TaiwanCheckBox:SetAsCheckBox()
 			window.TaiwanCheckBox:SetFixedParameter (5)
 			window.TaiwanCheckBox:SetTemplate (g:GetTemplate ("switch", "OPTIONS_CHECKBOX_TEMPLATE"))
@@ -555,10 +555,10 @@ local window_openned_at = time()
 			window_color:SetIcon ([[Interface\AddOns\Details\images\icons]], 14, 14, nil, {434/512, 466/512, 277/512, 307/512}, nil, 4, 2)
 
 		--bar height
-			g:NewLabel (window, _, "$parentBarHeightLabel", "BarHeightLabel", Loc ["STRING_OPTIONS_BAR_HEIGHT"] .. ":", "GameFontNormal")
+			g:NewLabel (window, nil, "$parentBarHeightLabel", "BarHeightLabel", Loc ["STRING_OPTIONS_BAR_HEIGHT"] .. ":", "GameFontNormal")
 			window.BarHeightLabel:SetPoint ("topleft", window_color, "bottomleft", 0, -4 + padding)
 			--
-			g:NewSlider (window, _, "$parentBarHeightSpeed", "BarHeightSlider", 160, 20, 8, 24, 1, 14) --parent, container, name, member, w, h, min, max, step, defaultv
+			g:NewSlider (window, nil, "$parentBarHeightSpeed", "BarHeightSlider", 160, 20, 8, 24, 1, 14) --parent, container, name, member, w, h, min, max, step, defaultv
 			window.BarHeightSlider:SetPoint ("left", window.BarHeightLabel, "right", 2, 0)
 			window.BarHeightSlider:SetTemplate (g:GetTemplate ("slider", "OPTIONS_SLIDER_TEMPLATE"))
 			
@@ -575,10 +575,10 @@ local window_openned_at = time()
 			end)
 
 		--text size
-			g:NewLabel (window, _, "$parentTextSizeLabel", "TextSizeLabel", Loc ["STRING_OPTIONS_TEXT_SIZE"] .. ":", "GameFontNormal")
+			g:NewLabel (window, nil, "$parentTextSizeLabel", "TextSizeLabel", Loc ["STRING_OPTIONS_TEXT_SIZE"] .. ":", "GameFontNormal")
 			window.TextSizeLabel:SetPoint ("topleft", window.BarHeightLabel, "bottomleft", 0, -4 + padding)
 			--
-			g:NewSlider (window, _, "$parentTextSizeSpeed", "TextSizeSlider", 160, 20, 10, 20, 1, 14) --parent, container, name, member, w, h, min, max, step, defaultv
+			g:NewSlider (window, nil, "$parentTextSizeSpeed", "TextSizeSlider", 160, 20, 10, 20, 1, 14) --parent, container, name, member, w, h, min, max, step, defaultv
 			window.TextSizeSlider:SetPoint ("left", window.TextSizeLabel, "right", 2, 0)
 			window.TextSizeSlider:SetTemplate (g:GetTemplate ("slider", "OPTIONS_SLIDER_TEMPLATE"))
 			
@@ -618,17 +618,17 @@ local window_openned_at = time()
 			end
 			
 			local instance1 = _detalhes:GetInstance (1)
-			local font_dropdown = g:NewDropDown (window, _, "$parentFontDropdown", "FontDropdown", 160, 20, buildFontMenu, instance1.row_info.font_face)
+			local font_dropdown = g:NewDropDown (window, nil, "$parentFontDropdown", "FontDropdown", 160, 20, buildFontMenu, instance1.row_info.font_face)
 			font_dropdown:SetTemplate (g:GetTemplate ("dropdown", "OPTIONS_DROPDOWN_TEMPLATE"))
 			font_dropdown.tooltip = Loc ["STRING_WELCOME_58"]
 			
-			local font_label = g:NewLabel (window, _, "$parentFontLabel", "FontLabel", Loc ["STRING_OPTIONS_TEXT_FONT"], "GameFontNormal")
+			local font_label = g:NewLabel (window, nil, "$parentFontLabel", "FontLabel", Loc ["STRING_OPTIONS_TEXT_FONT"], "GameFontNormal")
 			font_dropdown:SetPoint ("left", font_label, "right", 2)
 			font_label:SetPoint ("topleft", window.TextSizeLabel, "bottomleft", 0, -4 + padding)
 		
 		--show percent
-			g:NewLabel (window, _, "$parentShowPercentLabel", "ShowPercentLabel", Loc ["STRING_OPTIONS_TEXT_SHOW_PERCENT"], "GameFontNormal")
-			g:NewSwitch (window, _, "$parentShowPercentCheckBox", "ShowPercentCheckBox", 20, 20, _, _, false)
+			g:NewLabel (window, nil, "$parentShowPercentLabel", "ShowPercentLabel", Loc ["STRING_OPTIONS_TEXT_SHOW_PERCENT"], "GameFontNormal")
+			g:NewSwitch (window, nil, "$parentShowPercentCheckBox", "ShowPercentCheckBox", 20, 20, nil, nil, false)
 			window.ShowPercentCheckBox:SetAsCheckBox()
 			window.ShowPercentCheckBox:SetFixedParameter (1)
 			window.ShowPercentCheckBox:SetTemplate (g:GetTemplate ("switch", "OPTIONS_CHECKBOX_TEMPLATE"))
@@ -699,7 +699,7 @@ local window_openned_at = time()
 		numeral_image:SetAlpha (.05)
 		numeral_image:SetTexCoord (1, 0, 0, 1)		
 		
-		g:NewLabel (window, _, "$parentChangeMindNumeralLabel", "changemindNumeralLabel", Loc ["STRING_WELCOME_2"], "GameFontNormal", 9, "orange")
+		g:NewLabel (window, nil, "$parentChangeMindNumeralLabel", "changemindNumeralLabel", Loc ["STRING_WELCOME_2"], "GameFontNormal", 9, "orange")
 		window.changemindNumeralLabel:SetPoint ("center", window, "center")
 		window.changemindNumeralLabel:SetPoint ("bottom", window, "bottom", 0, 19)
 		window.changemindNumeralLabel.align = "|"
@@ -709,8 +709,8 @@ local window_openned_at = time()
 		texto2Numeral:SetText (Loc ["STRING_NUMERALSYSTEM_DESC"] .. ":")
 		
 		--numeral 1 - western
-		g:NewLabel (window, _, "$parentWesternNumbersLabel", "WesternNumbersLabel", Loc ["STRING_NUMERALSYSTEM_ARABIC_WESTERN"] .. ": " .. Loc ["STRING_NUMERALSYSTEM_ARABIC_WESTERN_DESC"], "GameFontHighlightLeft")
-		local WesternNumbersCheckbox = g:NewSwitch (window, _, "WesternNumbersCheckbox", "WesternNumbersCheckbox", 20, 20, _, _, true)
+		g:NewLabel (window, nil, "$parentWesternNumbersLabel", "WesternNumbersLabel", Loc ["STRING_NUMERALSYSTEM_ARABIC_WESTERN"] .. ": " .. Loc ["STRING_NUMERALSYSTEM_ARABIC_WESTERN_DESC"], "GameFontHighlightLeft")
+		local WesternNumbersCheckbox = g:NewSwitch (window, nil, "WesternNumbersCheckbox", "WesternNumbersCheckbox", 20, 20, nil, nil, true)
 		WesternNumbersCheckbox:SetAsCheckBox()
 		WesternNumbersCheckbox:SetFixedParameter (1)
 		WesternNumbersCheckbox:SetTemplate (g:GetTemplate ("switch", "OPTIONS_CHECKBOX_TEMPLATE"))
@@ -718,8 +718,8 @@ local window_openned_at = time()
 		window.WesternNumbersLabel:SetPoint ("left", WesternNumbersCheckbox, "right", 2, 0)
 		
 		--numeral 2 asian
-		g:NewLabel (window, _, "$parentAsianNumbersLabel", "AsianNumbersLabel", Loc ["STRING_NUMERALSYSTEM_MYRIAD_EASTASIA"] .. ": " .. Loc ["STRING_NUMERALSYSTEM_ARABIC_MYRIAD_EASTASIA"], "GameFontHighlightLeft")
-		local AsianNumbersCheckbox = g:NewSwitch (window, _, "AsianNumbersCheckbox", "AsianNumbersCheckbox", 20, 20, _, _, true)
+		g:NewLabel (window, nil, "$parentAsianNumbersLabel", "AsianNumbersLabel", Loc ["STRING_NUMERALSYSTEM_MYRIAD_EASTASIA"] .. ": " .. Loc ["STRING_NUMERALSYSTEM_ARABIC_MYRIAD_EASTASIA"], "GameFontHighlightLeft")
+		local AsianNumbersCheckbox = g:NewSwitch (window, nil, "AsianNumbersCheckbox", "AsianNumbersCheckbox", 20, 20, nil, nil, true)
 		AsianNumbersCheckbox:SetAsCheckBox()
 		AsianNumbersCheckbox:SetFixedParameter (2)
 		AsianNumbersCheckbox:SetTemplate (g:GetTemplate ("switch", "OPTIONS_CHECKBOX_TEMPLATE"))
@@ -818,7 +818,7 @@ local window_openned_at = time()
 		ampulheta:SetAlpha (.05)
 		ampulheta:SetTexCoord (1, 0, 0, 1)		
 		
-		g:NewLabel (window, _, "$parentChangeMind2Label", "changemind2Label", Loc ["STRING_WELCOME_2"], "GameFontNormal", 9, "orange")
+		g:NewLabel (window, nil, "$parentChangeMind2Label", "changemind2Label", Loc ["STRING_WELCOME_2"], "GameFontNormal", 9, "orange")
 		window.changemind2Label:SetPoint ("center", window, "center")
 		window.changemind2Label:SetPoint ("bottom", window, "bottom", 0, 19)
 		window.changemind2Label.align = "|"
@@ -828,16 +828,16 @@ local window_openned_at = time()
 		texto2:SetText (Loc ["STRING_WELCOME_3"])
 		
 		--chronometer checkbox
-		g:NewLabel (window, _, "$parentChronometerLabel", "ChronometerLabel", Loc ["STRING_WELCOME_4"], "GameFontHighlightLeft")
-		local chronometer = g:NewSwitch (window, _, "WelcomeWindowChronometer", "WelcomeWindowChronometer", 20, 20, _, _, true)
+		g:NewLabel (window, nil, "$parentChronometerLabel", "ChronometerLabel", Loc ["STRING_WELCOME_4"], "GameFontHighlightLeft")
+		local chronometer = g:NewSwitch (window, nil, "WelcomeWindowChronometer", "WelcomeWindowChronometer", 20, 20, nil, nil, true)
 		chronometer:SetAsCheckBox()
 		chronometer:SetFixedParameter (1)
 		chronometer:SetTemplate (g:GetTemplate ("switch", "OPTIONS_CHECKBOX_TEMPLATE"))
 		window.ChronometerLabel:SetPoint ("left", chronometer, "right", 2, 0)
 		
 		--continuouses checkbox
-		g:NewLabel (window, _, "$parentContinuousLabel", "ContinuousLabel", Loc ["STRING_WELCOME_5"], "GameFontHighlightLeft")
-		local continuous = g:NewSwitch (window, _, "WelcomeWindowContinuous", "WelcomeWindowContinuous", 20, 20, _, _, true)
+		g:NewLabel (window, nil, "$parentContinuousLabel", "ContinuousLabel", Loc ["STRING_WELCOME_5"], "GameFontHighlightLeft")
+		local continuous = g:NewSwitch (window, nil, "WelcomeWindowContinuous", "WelcomeWindowContinuous", 20, 20, nil, nil, true)
 		continuous:SetAsCheckBox()
 		continuous:SetFixedParameter (1)
 		continuous:SetTemplate (g:GetTemplate ("switch", "OPTIONS_CHECKBOX_TEMPLATE"))
@@ -958,7 +958,7 @@ local window_openned_at = time()
 		bg:SetAlpha (.05)
 		bg:SetTexCoord (1, 0, 0, 1)
 		
-		g:NewLabel (window, _, "$parentChangeMind4Label", "changemind4Label", Loc ["STRING_WELCOME_11"], "GameFontNormal", 9, "orange")
+		g:NewLabel (window, nil, "$parentChangeMind4Label", "changemind4Label", Loc ["STRING_WELCOME_11"], "GameFontNormal", 9, "orange")
 		window.changemind4Label:SetPoint ("center", window, "center")
 		window.changemind4Label:SetPoint ("bottom", window, "bottom", 0, 19)
 		window.changemind4Label.align = "|"
@@ -986,11 +986,11 @@ local window_openned_at = time()
 		dance_text:SetPoint ("topleft", window, "topleft", 30, -175)
 		
 	--------------- Update Speed
-		g:NewLabel (window, _, "$parentUpdateSpeedLabel", "updatespeedLabel", Loc ["STRING_OPTIONS_WINDOWSPEED"] .. ":", "GameFontNormal")
+		g:NewLabel (window, nil, "$parentUpdateSpeedLabel", "updatespeedLabel", Loc ["STRING_OPTIONS_WINDOWSPEED"] .. ":", "GameFontNormal")
 		window.updatespeedLabel:SetPoint (31, -150)
 		--
 		
-		g:NewSlider (window, _, "$parentSliderUpdateSpeed", "updatespeedSlider", 160, 20, 0.050, 3, 0.050, _detalhes.update_speed, true) --parent, container, name, member, w, h, min, max, step, defaultv
+		g:NewSlider (window, nil, "$parentSliderUpdateSpeed", "updatespeedSlider", 160, 20, 0.050, 3, 0.050, _detalhes.update_speed, true) --parent, container, name, member, w, h, min, max, step, defaultv
 		window.updatespeedSlider:SetPoint ("left", window.updatespeedLabel, "right", 2, 0)
 		window.updatespeedSlider:SetTemplate (g:GetTemplate ("slider", "OPTIONS_SLIDER_TEMPLATE"))
 		window.updatespeedSlider:SetThumbSize (50)
@@ -1018,10 +1018,10 @@ local window_openned_at = time()
 		window.updatespeedSlider.tooltip = Loc ["STRING_WELCOME_15"]
 		
 	--------------- Animate Rows
-		g:NewLabel (window, _, "$parentAnimateLabel", "animateLabel", Loc ["STRING_OPTIONS_ANIMATEBARS"] .. ":", "GameFontNormal")
+		g:NewLabel (window, nil, "$parentAnimateLabel", "animateLabel", Loc ["STRING_OPTIONS_ANIMATEBARS"] .. ":", "GameFontNormal")
 		window.animateLabel:SetPoint (31, -170)
 		--
-		g:NewSwitch (window, _, "$parentAnimateSlider", "animateSlider", 60, 20, _, _, _detalhes.use_row_animations) -- ltext, rtext, defaultv
+		g:NewSwitch (window, nil, "$parentAnimateSlider", "animateSlider", 60, 20, nil, nil, _detalhes.use_row_animations) -- ltext, rtext, defaultv
 		window.animateSlider:SetPoint ("left",window.animateLabel, "right", 2, 0)
 		window.animateSlider.OnSwitch = function (self, _, value) --> slider, fixedValue, sliderValue (false, true)
 			_detalhes:SetUseAnimations (value)
@@ -1033,10 +1033,10 @@ local window_openned_at = time()
 		
 	--------------- Fast Hps/Dps Updates
 	--[
-		g:NewLabel (window, _, "$parentDpsHpsLabel", "DpsHpsLabel", Loc ["STRING_WELCOME_63"] .. ":", "GameFontNormal")
+		g:NewLabel (window, nil, "$parentDpsHpsLabel", "DpsHpsLabel", Loc ["STRING_WELCOME_63"] .. ":", "GameFontNormal")
 		window.DpsHpsLabel:SetPoint (31, -190)
 		--
-		g:NewSwitch (window, _, "$parentDpsHpsSlider", "DpsHpsSlider", 60, 20, _, _, _detalhes:GetInstance(1).row_info.fast_ps_update) -- ltext, rtext, defaultv
+		g:NewSwitch (window, nil, "$parentDpsHpsSlider", "DpsHpsSlider", 60, 20, nil, nil, _detalhes:GetInstance(1).row_info.fast_ps_update) -- ltext, rtext, defaultv
 		window.DpsHpsSlider:SetPoint ("left",window.DpsHpsLabel, "right", 2, 0)
 		window.DpsHpsSlider.OnSwitch = function (self, _, value) --> slider, fixedValue, sliderValue (false, true)
 			_detalhes:GetInstance(1):FastPSUpdate (value)
@@ -1048,10 +1048,10 @@ local window_openned_at = time()
 		--window.DpsHpsSlider.tooltip = Loc ["STRING_WELCOME_64"]
 	--]]
 	--------------- Max Segments
-	--	g:NewLabel (window, _, "$parentSliderLabel", "segmentsLabel", Loc ["STRING_WELCOME_21"] .. ":", "GameFontNormal")
+	--	g:NewLabel (window, nil, "$parentSliderLabel", "segmentsLabel", Loc ["STRING_WELCOME_21"] .. ":", "GameFontNormal")
 	--	window.segmentsLabel:SetPoint (31, -210)
 		--
-	--	g:NewSlider (window, _, "$parentSlider", "segmentsSlider", 120, 20, 1, 25, 1, _detalhes.segments_amount) -- min, max, step, defaultv
+	--	g:NewSlider (window, nil, "$parentSlider", "segmentsSlider", 120, 20, 1, 25, 1, _detalhes.segments_amount) -- min, max, step, defaultv
 	--	window.segmentsSlider:SetPoint ("left", window.segmentsLabel, "right", 2, 0)
 	--	window.segmentsSlider:SetHook ("OnValueChange", function (self, _, amount) --> slider, fixedValue, sliderValue
 	--		_detalhes.segments_amount = math.floor (amount)

--- a/functions/dungeon.lua
+++ b/functions/dungeon.lua
@@ -322,7 +322,7 @@ function mythicDungeonCharts.ShowReadyPanel()
 		local on_switch_enable = function (self, _, value)
 			_detalhes.mythic_plus.show_damage_graphic = not value
 		end
-		local notAgainSwitch, notAgainLabel = DetailsFramework:CreateSwitch (f, on_switch_enable, not _detalhes.mythic_plus.show_damage_graphic, _, _, _, _, _, _, _, _, _, Loc ["STRING_MINITUTORIAL_BOOKMARK4"], DetailsFramework:GetTemplate ("switch", "OPTIONS_CHECKBOX_BRIGHT_TEMPLATE"), "GameFontHighlightLeft")
+		local notAgainSwitch, notAgainLabel = DetailsFramework:CreateSwitch (f, on_switch_enable, not _detalhes.mythic_plus.show_damage_graphic, nil, nil, nil, nil, nil, nil, nil, nil, nil, Loc ["STRING_MINITUTORIAL_BOOKMARK4"], DetailsFramework:GetTemplate ("switch", "OPTIONS_CHECKBOX_BRIGHT_TEMPLATE"), "GameFontHighlightLeft")
 		notAgainSwitch:ClearAllPoints()
 		notAgainLabel:SetPoint ("left", notAgainSwitch, "right", 2, 0)
 		notAgainSwitch:SetPoint ("bottomleft", f, "bottomleft", 5, 5)
@@ -526,7 +526,7 @@ function mythicDungeonCharts.ShowChart()
 		local on_switch_enable = function (_, _, state)
 			_detalhes.mythic_plus.show_damage_graphic = state
 		end
-		local enabledSwitch, enabledLabel = Details.gump:CreateSwitch (f, on_switch_enable, _detalhes.mythic_plus.show_damage_graphic, _, _, _, _, _, _, _, _, _, "Enabled", Details.gump:GetTemplate ("switch", "OPTIONS_CHECKBOX_BRIGHT_TEMPLATE"), "GameFontHighlightLeft")
+		local enabledSwitch, enabledLabel = Details.gump:CreateSwitch (f, on_switch_enable, _detalhes.mythic_plus.show_damage_graphic, nil, nil, nil, nil, nil, nil, nil, nil, nil, "Enabled", Details.gump:GetTemplate ("switch", "OPTIONS_CHECKBOX_BRIGHT_TEMPLATE"), "GameFontHighlightLeft")
 		enabledSwitch:SetAsCheckBox()
 		enabledSwitch.tooltip = "Show this chart at the end of a mythic dungeon run.\n\nIf disabled, you can reactivate it again at the options panel > streamer settings."
 		enabledLabel:SetPoint ("right", minimizeButton, "left", -22, 0)

--- a/functions/events.lua
+++ b/functions/events.lua
@@ -249,7 +249,7 @@ local common_events = {
 		
 		if (not okay) then
 			--> trigger an error msg
-			dispatch_error (_, errortext)
+			dispatch_error (nil, errortext)
 			
 			return
 		end

--- a/functions/loaddata.lua
+++ b/functions/loaddata.lua
@@ -187,7 +187,7 @@ function _detalhes:LoadCombatTables()
 		if (not _detalhes_database.tabela_historico) then
 			_detalhes.tabela_historico = _detalhes.historico:NovoHistorico()
 			_detalhes.tabela_overall = _detalhes.combate:NovaTabela()
-			_detalhes.tabela_vigente = _detalhes.combate:NovaTabela (_, _detalhes.tabela_overall)
+			_detalhes.tabela_vigente = _detalhes.combate:NovaTabela (nil, _detalhes.tabela_overall)
 			_detalhes.tabela_pets = _detalhes.container_pets:NovoContainer()
 			_detalhes:UpdateContainerCombatentes()
 		else
@@ -210,7 +210,7 @@ function _detalhes:LoadCombatTables()
 					--> details was been hard upgraded
 					_detalhes.tabela_historico = _detalhes.historico:NovoHistorico()
 					_detalhes.tabela_overall = _detalhes.combate:NovaTabela()
-					_detalhes.tabela_vigente = _detalhes.combate:NovaTabela (_, _detalhes.tabela_overall)
+					_detalhes.tabela_vigente = _detalhes.combate:NovaTabela (nil, _detalhes.tabela_overall)
 					_detalhes.tabela_pets = _detalhes.container_pets:NovoContainer()
 					_detalhes:UpdateContainerCombatentes()
 					
@@ -223,7 +223,7 @@ function _detalhes:LoadCombatTables()
 						if (not combat[1] or not combat[2] or not combat[3] or not combat[4]) then
 							--> something went wrong in last logon, let's just reset and we are good to go
 							_detalhes.tabela_historico = _detalhes.historico:NovoHistorico()
-							_detalhes.tabela_vigente = _detalhes.combate:NovaTabela (_, _detalhes.tabela_overall)
+							_detalhes.tabela_vigente = _detalhes.combate:NovaTabela (nil, _detalhes.tabela_overall)
 							_detalhes.tabela_pets = _detalhes.container_pets:NovoContainer()
 							_detalhes:UpdateContainerCombatentes()
 						end
@@ -248,7 +248,7 @@ function _detalhes:LoadCombatTables()
 				if (historico_UM) then
 					_detalhes.tabela_vigente = historico_UM --> significa que elas eram a mesma tabela, ent�o aqui elas se tornam a mesma tabela
 				else
-					_detalhes.tabela_vigente = _detalhes.combate:NovaTabela (_, _detalhes.tabela_overall)
+					_detalhes.tabela_vigente = _detalhes.combate:NovaTabela (nil, _detalhes.tabela_overall)
 				end
 				
 			--> need refresh for all containers

--- a/functions/slash.lua
+++ b/functions/slash.lua
@@ -146,7 +146,7 @@ function SlashCmdList.DETAILS (msg, editbox)
 			local lower_instance = _detalhes:GetLowerInstanceNumber()
 			if (not lower_instance) then
 				local instance = _detalhes:GetInstance (1)
-				_detalhes.CriarInstancia (_, _, 1)
+				_detalhes.CriarInstancia (nil, nil, 1)
 				_detalhes:OpenOptionsWindow (instance)
 			else
 				_detalhes:OpenOptionsWindow (_detalhes:GetInstance (lower_instance))
@@ -199,11 +199,11 @@ function SlashCmdList.DETAILS (msg, editbox)
 
 	elseif (command == "bosstimers" or command == "bosstimer" or command == "timer" or command == "timers") then
 		Details.OpenForge()
-		DetailsForgePanel.SelectModule (_, _, 4)
+		DetailsForgePanel.SelectModule (nil, nil, 4)
 
 	elseif (command == "spells") then
 		Details.OpenForge()
-		DetailsForgePanel.SelectModule (_, _, 1)
+		DetailsForgePanel.SelectModule (nil, nil, 1)
 		
 	elseif (msg == "WA" or msg == "wa" or msg == "Wa" or msg == "wA") then
 		_G.DetailsPluginContainerWindow.OpenPlugin(_G.DetailsAuraPanel)

--- a/functions/timedata.lua
+++ b/functions/timedata.lua
@@ -267,7 +267,7 @@
 			if (not time or time == 0) then
 				return 0
 			else
-				return ToKFunctions [_detalhes.minimap.text_format] (_, combat.totals_grupo[1] / time)
+				return ToKFunctions [_detalhes.minimap.text_format] (nil, combat.totals_grupo[1] / time)
 			end
 		end,
 		-- raid hps [2]
@@ -277,7 +277,7 @@
 			if (not time or time == 0) then
 				return 0
 			else
-				return ToKFunctions [_detalhes.minimap.text_format] (_, combat.totals_grupo[2] / time)
+				return ToKFunctions [_detalhes.minimap.text_format] (nil, combat.totals_grupo[2] / time)
 			end
 		end
 	}
@@ -353,7 +353,7 @@
 				
 				if (second) then
 					local diff = first.total - second.total
-					return "+" .. ToKFunctions [_detalhes.minimap.text_format] (_, diff)
+					return "+" .. ToKFunctions [_detalhes.minimap.text_format] (nil, diff)
 				else
 					return "0"
 				end
@@ -362,9 +362,9 @@
 				if (player) then
 					player = damage_container._ActorTable [player]
 					local diff = first.total - player.total
-					return "-" .. ToKFunctions [_detalhes.minimap.text_format] (_, diff)
+					return "-" .. ToKFunctions [_detalhes.minimap.text_format] (nil, diff)
 				else
-					return ToKFunctions [_detalhes.minimap.text_format] (_, first.total)
+					return ToKFunctions [_detalhes.minimap.text_format] (nil, first.total)
 				end
 			end
 		else
@@ -399,7 +399,7 @@
 				
 				if (second) then
 					local diff = first.total - second.total
-					return "+" .. ToKFunctions [_detalhes.minimap.text_format] (_, diff)
+					return "+" .. ToKFunctions [_detalhes.minimap.text_format] (nil, diff)
 				else
 					return "0"
 				end
@@ -408,9 +408,9 @@
 				if (player) then
 					player = heal_container._ActorTable [player]
 					local diff = first.total - player.total
-					return "-" .. ToKFunctions [_detalhes.minimap.text_format] (_, diff)
+					return "-" .. ToKFunctions [_detalhes.minimap.text_format] (nil, diff)
 				else
-					return ToKFunctions [_detalhes.minimap.text_format] (_, first.total)
+					return ToKFunctions [_detalhes.minimap.text_format] (nil, first.total)
 				end
 			end
 		else
@@ -424,14 +424,14 @@
 			if (_detalhes.time_type == 1) then --activity time
 				local combat_time = damage_player:Tempo()
 				if (combat_time > 0) then
-					return ToKFunctions [_detalhes.minimap.text_format] (_, damage_player.total / combat_time)
+					return ToKFunctions [_detalhes.minimap.text_format] (nil, damage_player.total / combat_time)
 				else
 					return 0
 				end
 			else --effective time
 				local combat_time = _detalhes.tabela_vigente:GetCombatTime()
 				if (combat_time > 0) then
-					return ToKFunctions [_detalhes.minimap.text_format] (_, damage_player.total / combat_time)
+					return ToKFunctions [_detalhes.minimap.text_format] (nil, damage_player.total / combat_time)
 				else
 					return 0
 				end
@@ -448,14 +448,14 @@
 			if (_detalhes.time_type == 1) then --activity time
 				local combat_time = heal_player:Tempo()
 				if (combat_time > 0) then
-					return ToKFunctions [_detalhes.minimap.text_format] (_, heal_player.total / combat_time)
+					return ToKFunctions [_detalhes.minimap.text_format] (nil, heal_player.total / combat_time)
 				else
 					return 0
 				end
 			else --effective time
 				local combat_time = _detalhes.tabela_vigente:GetCombatTime()
 				if (combat_time > 0) then
-					return ToKFunctions [_detalhes.minimap.text_format] (_, heal_player.total / combat_time)
+					return ToKFunctions [_detalhes.minimap.text_format] (nil, heal_player.total / combat_time)
 				else
 					return 0
 				end
@@ -469,7 +469,7 @@
 	local get_raid_dps = function()
 		local damage_raid = _detalhes.tabela_vigente and _detalhes.tabela_vigente.totals [1]
 		if (damage_raid ) then
-			return ToKFunctions [_detalhes.minimap.text_format] (_, damage_raid / _detalhes.tabela_vigente:GetCombatTime())
+			return ToKFunctions [_detalhes.minimap.text_format] (nil, damage_raid / _detalhes.tabela_vigente:GetCombatTime())
 		else
 			return 0
 		end
@@ -478,7 +478,7 @@
 	local get_raid_hps = function()
 		local healing_raid = _detalhes.tabela_vigente and _detalhes.tabela_vigente.totals [2]
 		if (healing_raid ) then
-			return ToKFunctions [_detalhes.minimap.text_format] (_, healing_raid / _detalhes.tabela_vigente:GetCombatTime())
+			return ToKFunctions [_detalhes.minimap.text_format] (nil, healing_raid / _detalhes.tabela_vigente:GetCombatTime())
 		else
 			return 0
 		end
@@ -487,7 +487,7 @@
 	local get_player_damage = function()
 		local damage_player = _detalhes.tabela_vigente(1, _detalhes.playername)
 		if (damage_player) then
-			return ToKFunctions [_detalhes.minimap.text_format] (_, damage_player.total)
+			return ToKFunctions [_detalhes.minimap.text_format] (nil, damage_player.total)
 		else
 			return 0
 		end
@@ -496,7 +496,7 @@
 	local get_player_heal = function()
 		local heal_player = _detalhes.tabela_vigente (2, _detalhes.playername)
 		if (heal_player) then
-			return ToKFunctions [_detalhes.minimap.text_format] (_, heal_player.total)
+			return ToKFunctions [_detalhes.minimap.text_format] (nil, heal_player.total)
 		else
 			return 0
 		end

--- a/plugins/Details_EncounterDetails/Details_EncounterDetails.lua
+++ b/plugins/Details_EncounterDetails/Details_EncounterDetails.lua
@@ -856,7 +856,7 @@ local function EnemySkills (habilidade, barra)
 	for index, tabela in _ipairs (tabela_jogadores) do
 		local coords = EncounterDetails.class_coords [tabela[3]]
 		
-		GameCooltip:AddLine (EncounterDetails:GetOnlyName (tabela[1]), ToK (_, tabela[2]) .. " (" .. format ("%.1f", tabela[2] / total * 100) .. "%)", 1, "white")
+		GameCooltip:AddLine (EncounterDetails:GetOnlyName (tabela[1]), ToK (nil, tabela[2]) .. " (" .. format ("%.1f", tabela[2] / total * 100) .. "%)", 1, "white")
 		local r, g, b, a = unpack (_detalhes.tooltip.background)
 		
 		local actorClass = Details:GetClass (tabela[1])
@@ -937,7 +937,7 @@ local function DamageTakenDetails (jogador, barra)
 			teve_melee = true
 		end
 		
-		GameCooltip:AddLine (nome_magia, ToK (_, meus_agressores[i][2]) .. " (".._cstr("%.1f", (meus_agressores[i][2]/damage_taken) * 100).."%)", 1, "white")
+		GameCooltip:AddLine (nome_magia, ToK (nil, meus_agressores[i][2]) .. " (".._cstr("%.1f", (meus_agressores[i][2]/damage_taken) * 100).."%)", 1, "white")
 		GameCooltip:AddStatusBar (meus_agressores[i][2] / topDamage * 100, 1, .55, .55, .55, .834, false, {value = 100, color = {.21, .21, .21, 0.8}, texture = [[Interface\AddOns\Details\images\bar_serenity]]})
 		
 		GameCooltip:AddIcon (icone_magia, nil, 1, EncounterDetails.CooltipLineHeight - 0, EncounterDetails.CooltipLineHeight - 0, .1, .9, .1, .9)
@@ -1282,7 +1282,7 @@ function EncounterDetails:OpenAndRefresh (_, segment)
 			combat tables have 4 containers [1] damage [2] heal [3] energy [4] misc each container have 2 tables: ._NameIndexTable and ._ActorTable --]]
 		local DamageContainer = _combat_object [class_type_damage]
 		
-		local damage_taken = _detalhes.atributo_damage:RefreshWindow ({}, _combat_object, _, { key = "damage_taken", modo = _detalhes.modos.group })
+		local damage_taken = _detalhes.atributo_damage:RefreshWindow ({}, _combat_object, nil, { key = "damage_taken", modo = _detalhes.modos.group })
 		
 		local container = frame.overall_damagetaken.gump
 		
@@ -1312,7 +1312,7 @@ function EncounterDetails:OpenAndRefresh (_, segment)
 					barra.lineText1:SetText (jogador.nome)
 				end
 				
-				barra.lineText4:SetText (ToK (_, jogador.damage_taken))
+				barra.lineText4:SetText (ToK (nil, jogador.damage_taken))
 				
 				_detalhes:name_space (barra)
 				
@@ -1527,7 +1527,7 @@ function EncounterDetails:OpenAndRefresh (_, segment)
 				local nome_magia, _, icone_magia = _GetSpellInfo (habilidade[4])
 
 				barra.lineText1:SetText (nome_magia) --  .. " (|cFFa0a0a0" .. habilidade[4] .. "|r)
-				barra.lineText4:SetText (ToK (_, habilidade[1]))
+				barra.lineText4:SetText (ToK (nil, habilidade[1]))
 				
 				_detalhes:name_space (barra)
 				
@@ -1844,7 +1844,7 @@ function EncounterDetails:OpenAndRefresh (_, segment)
 	
 		local misc = _combat_object [class_type_misc]
 		
-		local total_interrompido = _detalhes.atributo_misc:RefreshWindow ({}, _combat_object, _, { key = "interrupt", modo = _detalhes.modos.group })
+		local total_interrompido = _detalhes.atributo_misc:RefreshWindow ({}, _combat_object, nil, { key = "interrupt", modo = _detalhes.modos.group })
 		
 		local frame_interrupts = EncounterDetailsFrame.overall_interrupt
 		container = frame_interrupts.gump
@@ -1953,7 +1953,7 @@ function EncounterDetails:OpenAndRefresh (_, segment)
 	--> Inicio do Container dos Dispells:
 		
 		--> force refresh window behavior
-		local total_dispelado = _detalhes.atributo_misc:RefreshWindow ({}, _combat_object, _, { key = "dispell", modo = _detalhes.modos.group })
+		local total_dispelado = _detalhes.atributo_misc:RefreshWindow ({}, _combat_object, nil, { key = "dispell", modo = _detalhes.modos.group })
 		
 		local frame_dispell = EncounterDetailsFrame.overall_dispell
 		container = frame_dispell.gump

--- a/plugins/Details_EncounterDetails/frames.lua
+++ b/plugins/Details_EncounterDetails/frames.lua
@@ -1621,7 +1621,7 @@ _detalhes.EncounterDetailsTempWindow = function (EncounterDetails)
 		end
 		return t
 	end
-	local dropdown = DetailsFrameWork:NewDropDown (BossFrame, _, "$parentEmotesSegmentDropdown", "EmotesSegment", 180, 20, build_emote_segments, 1)
+	local dropdown = DetailsFrameWork:NewDropDown (BossFrame, nil, "$parentEmotesSegmentDropdown", "EmotesSegment", 180, 20, build_emote_segments, 1)
 	dropdown:SetPoint ("topleft", emotes_segment_label, "bottomleft", -1, -2)
 	dropdown:SetTemplate (DetailsFrameWork:GetTemplate ("dropdown", "OPTIONS_DROPDOWN_TEMPLATE"))
 	
@@ -2332,8 +2332,8 @@ local ScrollRefresh = function (self, data, offset, total_lines)
 			
 			line.icon:SetTexture (texture)
 			line.icon:SetTexCoord (L, R, T, B)
-			line.name:SetText (index .. ". " .. removeRealm (_, player[1]))
-			line.done:SetText (formatToK (_, player[2]) .. " (" .. format ("%.1f", player[2] / topValue * 100) .. "%)")
+			line.name:SetText (index .. ". " .. removeRealm (nil, player[1]))
+			line.done:SetText (formatToK (nil, player[2]) .. " (" .. format ("%.1f", player[2] / topValue * 100) .. "%)")
 			line.statusbar:SetValue (player[2] / topValue * 100)
 			local actorClass = Details:GetClass (player[1])
 			if (actorClass) then
@@ -2623,7 +2623,7 @@ end
 		segmentos_string:SetPoint ("bottomleft", frame, "bottomleft", 20, 16)
 		
 		-- ~dropdown
-		local segmentos = DetailsFrameWork:NewDropDown (frame, _, "$parentSegmentsDropdown", "segmentosDropdown", 160, 20, buildSegmentosMenu, nil)	
+		local segmentos = DetailsFrameWork:NewDropDown (frame, nil, "$parentSegmentsDropdown", "segmentosDropdown", 160, 20, buildSegmentosMenu, nil)	
 		segmentos:SetPoint ("left", segmentos_string, "right", 2, 0)
 		segmentos:SetTemplate (DetailsFrameWork:GetTemplate ("dropdown", "OPTIONS_DROPDOWN_TEMPLATE"))
 		

--- a/plugins/Details_Streamer/Details_Streamer.lua
+++ b/plugins/Details_Streamer/Details_Streamer.lua
@@ -2157,7 +2157,7 @@ function StreamOverlay.OpenOptionsPanel (from_options_panel)
 				dropdown_profile:Select (Details_StreamerDB.characters [pname])
 				
 			end
-			options_frame.NewProfileButton = Details.gump:CreateButton (options_frame, add_profile, 60, 18, "New Profiile", _, _, _, _, _, _, Details.gump:GetTemplate ("dropdown", "OPTIONS_DROPDOWN_TEMPLATE"), Details.gump:GetTemplate ("font", "OPTIONS_FONT_TEMPLATE"))
+			options_frame.NewProfileButton = Details.gump:CreateButton (options_frame, add_profile, 60, 18, "New Profiile", nil, nil, nil, nil, nil, nil, Details.gump:GetTemplate ("dropdown", "OPTIONS_DROPDOWN_TEMPLATE"), Details.gump:GetTemplate ("font", "OPTIONS_FONT_TEMPLATE"))
 			options_frame.NewProfileButton:SetPoint ("left", dropdown_profile, "right", 4, 0)
 		end
 		


### PR DESCRIPTION
 In some places _ is used as a parameter when calling a method. 

If some other addon by accident assigns some value to global variable "_" currently Details addon will use that variable [even though I guess "_" is to be nil]. 

In my case all labels in statistics tab have gotten to size 123 or smth like that :wink:

To reproduce:
`/reload`
`/script _=123`
 and then click options from Details and next go to "statistics" -> Huge texts.
 
 In my case the addon that wrote to _ was Button Forge, and that is why I noticed this.

This code is to replace all calls of methods which have used "_" as a parameter. This does not modify functions parameter definitions.