### PR TITLE
Fix for weird segment bug when swapping segments

### DIFF
--- a/classes/class_custom.lua
+++ b/classes/class_custom.lua
@@ -821,7 +821,6 @@
 				actor.nome = spellname
 				actor.name = spellname
 				actor.classe = actor.spellschool
-				actor.class = actor.spellschool
 				class = actor.spellschool
 				
 				local index = self._NameIndexTable [actor.nome]


### PR DESCRIPTION
When using a custom display that uses a spell, this line sets a numerical value to the `class` key, which conflicts with the default Details metatable `:class()` function that I ensure is on every custom object. Honestly, this is such a niche bug that it's stupid it happens. But when it does happen, no new segments are created. Soo, fix.