### PR TITLE
Allow Custom Tooltip to read keydown

### DIFF
--- a/classes/class_custom.lua
+++ b/classes/class_custom.lua
@@ -977,7 +977,7 @@
 				if (func) then
 					
 				end
-				local okey, errortext = _pcall (func, actor, instance.showing, instance)
+				local okey, errortext = _pcall (func, actor, instance.showing, instance, keydown)
 				if (not okey) then
 					_detalhes:Msg ("|cFFFF9900error on custom display tooltip function|r:", errortext)
 					return false


### PR DESCRIPTION
Since atributo_custom:ToolTip is provided the `keydown` state. It makes sense to pass that onto a custom tooltip to let it react to states like default tooltips.