### PR TITLE
Fix DynamicOverallDamage's Tooltip

### DIFF
--- a/classes/class_custom.lua
+++ b/classes/class_custom.lua
@@ -2283,7 +2283,7 @@
 			desc = "Show overall damage done on the fly.",
 			source = false,
 			target = false,
-			script_version = 6,
+			script_version = 7,
 			script = [[
 				--init:
 				local combat, instance_container, instance = ...
@@ -2353,12 +2353,14 @@
 				end
 
 				--current
-				local player = CurrentCombat [1]:GetActor (actor.nome)
-				if (player) then
-					playerTotal = playerTotal + player.total
-					local playerSpells = player:GetSpellList()
-					for spellID, spellTable in pairs (playerSpells) do
-						AllSpells [spellID] = (AllSpells [spellID] or 0) + (spellTable.total or 0)
+				if (Details.in_combat) then
+					local player = CurrentCombat [1]:GetActor (actor.nome)
+					if (player) then
+						playerTotal = playerTotal + player.total
+						local playerSpells = player:GetSpellList()
+						for spellID, spellTable in pairs (playerSpells) do
+							AllSpells [spellID] = (AllSpells [spellID] or 0) + (spellTable.total or 0)
+						end
 					end
 				end
 


### PR DESCRIPTION
Fix the issue that the Tooltip is double counting last combat when the combat is over.