### PR TITLE
Don't show TaintWarning frame if MiniMapBattlefieldFrame is hidden

### DIFF
--- a/startup.lua
+++ b/startup.lua
@@ -562,10 +562,10 @@ function Details:StartMeUp() --I'll never stop!
 							end
 						end
 		
-						taintWarning:Show()
-						taintWarning:SetPoint ("topleft", StaticPopup1, "bottomleft", 0, -10)
 						
 						if (MiniMapBattlefieldFrame:IsShown())then
+							taintWarning:Show()
+							taintWarning:SetPoint ("topleft", StaticPopup1, "bottomleft", 0, -10)
 							if (not originalPosition) then
 								local a = {}
 								for i = 1, MiniMapBattlefieldFrame:GetNumPoints() do


### PR DESCRIPTION
Evidently the taint warning no longer pops up on a queue pop. However, on any other taint warning from any other addon, the taintWarning frame would appear, and since there is no minimap button to relocate, would never be hidden.