### PR TITLE
Fix for Attribute menu on top screen

### DIFF
--- a/frames/window_main.lua
+++ b/frames/window_main.lua
@@ -8980,11 +8980,9 @@ local atributo_on_enter = function (self, motion, forced, from_click)
 	_detalhes:FormatCooltipBackdrop()
 	
 	_detalhes:SetMenuOwner (self, instancia)
-	if (instancia.toolbar_side == 2) then --bottom
-		GameCooltip:SetOption ("HeightAnchorMod", 0)
-	end
 	
-	GameCooltip:ShowCooltip (self)
+	
+	GameCooltip:ShowCooltip ()
 end
 
 local atributo_on_leave = function (self, motion, forced, from_click)


### PR DESCRIPTION
Fixes the position of the attribute menu overlapping the buttons when the direction is changed because too close to the edge of the screen