### PR TITLE
Add Reset on new PVP option

### DIFF
--- a/classes/container_segments.lua
+++ b/classes/container_segments.lua
@@ -398,7 +398,7 @@ function _detalhes:CheckFreeze (instancia, index_liberado, tabela)
 	end
 end
 
-function _detalhes:SetOverallResetOptions (reset_new_boss, reset_new_challenge, reset_on_logoff)
+function _detalhes:SetOverallResetOptions (reset_new_boss, reset_new_challenge, reset_on_logoff, reset_new_pvp)
 	if (reset_new_boss == nil) then
 		reset_new_boss = _detalhes.overall_clear_newboss
 	end
@@ -408,10 +408,14 @@ function _detalhes:SetOverallResetOptions (reset_new_boss, reset_new_challenge, 
 	if (reset_on_logoff == nil) then
 		reset_on_logoff = _detalhes.overall_clear_logout
 	end
+	if (reset_new_pvp == nil) then
+		reset_new_pvp = _detalhes.overall_clear_pvp
+	end
 	
 	_detalhes.overall_clear_newboss = reset_new_boss
 	_detalhes.overall_clear_newchallenge = reset_new_challenge
 	_detalhes.overall_clear_logout = reset_on_logoff
+	_detalhes.overall_clear_pvp	 = reset_new_pvp
 end
 
 function historico:resetar_overall()

--- a/core/parser.lua
+++ b/core/parser.lua
@@ -4891,6 +4891,9 @@ local SPELL_POWER_PAIN = SPELL_POWER_PAIN or (PowerEnum and PowerEnum.Pain) or 1
 			if (_detalhes.debug) then
 				_detalhes:Msg ("(debug) zone type is now 'pvp'.")
 			end
+			if(not _detalhes.is_in_battleground and _detalhes.overall_clear_pvp) then
+				_detalhes.tabela_historico:resetar_overall()
+			end
 			
 			_detalhes.is_in_battleground = true
 			
@@ -4930,6 +4933,9 @@ local SPELL_POWER_PAIN = SPELL_POWER_PAIN or (PowerEnum and PowerEnum.Pain) or 1
 			end
 		
 			if (not _detalhes.is_in_arena) then
+				if (_detalhes.overall_clear_pvp) then
+					_detalhes.tabela_historico:resetar_overall()
+				end
 				--> reset spec cache if broadcaster requested
 				if (_detalhes.streamer_config.reset_spec_cache) then
 					wipe (_detalhes.cached_specs)

--- a/frames/window_options2_sections.lua
+++ b/frames/window_options2_sections.lua
@@ -487,6 +487,16 @@ do
             },
             {--erase overall data on logout
                 type = "toggle",
+                get = function() return _detalhes.overall_clear_pvp end,
+                set = function (self, fixedparam, value)
+                    _detalhes:SetOverallResetOptions(nil, nil, nil, value)
+                    afterUpdate()
+                end,
+                name = "Clear On Start PVP", --localize-me
+                desc = "When enabled, overall data is automatically wiped when a new arena or battleground starts.", --localize-me
+            },
+            {--erase overall data on logout
+                type = "toggle",
                 get = function() return _detalhes.overall_clear_logout end,
                 set = function (self, fixedparam, value)
                     _detalhes:SetOverallResetOptions(nil, nil, value)

--- a/functions/profiles.lua
+++ b/functions/profiles.lua
@@ -987,6 +987,7 @@ local default_profile = {
 		overall_clear_newchallenge = true,
 		overall_clear_newtorghast = true,
 		overall_clear_logout = false,
+		overall_clear_pvp = true,
 		data_cleanup_logout = false,
 		close_shields = false,
 		pvp_as_group = true,


### PR DESCRIPTION
Allow users to reset the overall segment on a new PVP instance. BG/Arena