### PR TITLE
Add Github workflow to automatically package addon on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Package and release
+on:
+  push:
+    tags:
+      - '**'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Package and release
+        uses: BigWigsMods/packager@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
+      CF_API_KEY: ${{ secrets.CF_API_KEY }}
     steps:
       - name: Clone project
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,3 +17,5 @@ jobs:
           fetch-depth: 0
       - name: Package and release
         uses: BigWigsMods/packager@v2
+        with:
+          args: -d # Remove this line if you want the package to be automatically upload to CurseForge on tag push


### PR DESCRIPTION
This pull request aims at allowing WowUp users to install Details by using the "Install from URL" feature.

My changes simply add the `.github/workflows/release.yml` file. This file sets up a Github workflow using the [BigWigsMods/packager@v2](https://github.com/BigWigsMods/packager) action.
This workflow action generates an addon `.zip` file from a repository. It automatically triggers when a new tag has been pushed. To communicate with addon providers (*i.e.* Curseforge), it needs an API token. This token should be added as a *secret* of this repository, under the name `CF_API_KEY`.

I made some tests on my forked repository but I could not test communication with CurseForge API since my CurseForge account does not have permissions to manage the Details project. Anyway, once you set the `CF_API_KEY` secret, everything should work out of the box.
However I still recommend you to create a new branch in order to test things up before merging on the `master` branch. Moreover, it is possible to automatically upload the new package via the CurseForge API so that users have access to the new version on tag push. Right now, I disabled the upload to CurseForge in order to avoid publishing possibly-corrupted `.zip` files.