### PR TITLE
Display Grimrail Depot cannon damage as separate entity

### DIFF
--- a/classes/container_actors.lua
+++ b/classes/container_actors.lua
@@ -270,6 +270,14 @@
 						actorObject.displayName = Details.KyrianWeaponActorName
 						actorObject.customColor = Details.KyrianWeaponColor
 						nome = Details.KyrianWeaponActorName
+
+					elseif (Details.GrimrailDepotCannonWeaponSpellIds[spellId]) then
+						actorObject.spellicon = GetSpellTexture(Details.GrimrailDepotCannonWeaponActorSpellId)
+						actorObject.nome = Details.GrimrailDepotCannonWeaponActorName
+						actorObject.displayName = Details.GrimrailDepotCannonWeaponActorName
+						actorObject.customColor = Details.GrimrailDepotCannonWeaponColor
+						nome = Details.GrimrailDepotCannonWeaponActorName
+
 					else
 						actorObject.spellicon = GetSpellTexture(spellId)
 					end

--- a/core/parser.lua
+++ b/core/parser.lua
@@ -448,6 +448,16 @@
 		Details.KyrianWeaponActorSpellId = 328351 --for the icon
 		Details.KyrianWeaponColor = {0.729, 0.917, 1} --color
 
+		--cannon weapons on grimrail depot --remove on 10.0
+		--these detect the cannon weapon actor by the damage spellId
+		Details.GrimrailDepotCannonWeaponSpellIds = {
+			[160776] = true, --Homing Shell
+			[166545] = true, --Sharpnel Cannon
+		}
+		Details.GrimrailDepotCannonWeaponActorName = "Cannon"
+		Details.GrimrailDepotCannonWeaponActorSpellId = 166545 --for the icon
+		Details.GrimrailDepotCannonWeaponColor = {1, 0.353, 0.082} --color
+
 		--sanguine affix for m+
 		Details.SanguineHealActorName = GetSpellInfo(SPELLID_SANGUINE_HEAL)
 
@@ -463,6 +473,15 @@
 			--add kyrian weapons
 			Details.SpecialSpellActorsName[Details.KyrianWeaponActorName] = Details.KyrianWeaponActorSpellId
 			for spellId in pairs(Details.KyrianWeaponSpellIds) do
+				local spellName = GetSpellInfo(spellId)
+				if (spellName) then
+					Details.SpecialSpellActorsName[spellName] = spellId
+				end
+			end
+
+			--add grimrail depot cannon weapons
+			Details.SpecialSpellActorsName[Details.GrimrailDepotCannonWeaponActorName] = Details.GrimrailDepotCannonWeaponActorSpellId
+			for spellId in pairs(Details.GrimrailDepotCannonWeaponSpellIds) do
 				local spellName = GetSpellInfo(spellId)
 				if (spellName) then
 					Details.SpecialSpellActorsName[spellName] = spellId
@@ -621,6 +640,13 @@
 		--kyrian weapons
 		if (Details.KyrianWeaponSpellIds[spellid]) then
 			who_name = Details.KyrianWeaponActorName
+			who_flags = 0x514
+			who_serial = "Creature-0-3134-2289-28065-" .. spellid .. "-000164C698"
+		end
+
+		--grimail depot cannon
+		if (Details.GrimrailDepotCannonWeaponSpellIds[spellid]) then
+			who_name = Details.GrimrailDepotCannonWeaponActorName
 			who_flags = 0x514
 			who_serial = "Creature-0-3134-2289-28065-" .. spellid .. "-000164C698"
 		end


### PR DESCRIPTION
Hi there,

The [Grimrail Depot dungeon](https://www.youtube.com/watch?v=Avr6ZBbbN8Y) is back on retail in Shadowlands Season 4, and during the 2nd boss fight there is a phase where players need to shoot the boss with a cannon. Currently the cannon abilities are displayed as player damage, which results in unrealistic damage profiles.

I think it would be a great idea to show the cannon damage as a separate entity in the damage meter, similarily to the kyrian weapons in the Necrotic Wake dungeon.

I thought I should give it a try, so I moved these 2 abilities to this new entity called "Cannon":
- [Sharpnel Cannon](https://www.wowhead.com/spell=166545/shrapnel-cannon)
- [Homing Shell](https://www.wowhead.com/spell=160776/homing-shell)

I used the icon of the Sharpnel Cannon ability as the Cannon entity icon, as the Homing Shell icon is really similar to the fire mage one :)

Let me know what you think:

![grimrail](https://user-images.githubusercontent.com/3816644/183549863-72c270b4-2399-49a5-8107-0079643cb0e7.png)

