### PR TITLE
Provide Data1,2,3 to custom text funcs

### DIFF
--- a/core/util.lua
+++ b/core/util.lua
@@ -743,7 +743,7 @@
 			function_cache [str] = func
 		end
 	
-		local okey, value = _pcall (func, parameters_cache [1], parameters_cache [2], parameters_cache [3], parameters_cache [4])
+		local okey, value = _pcall (func, parameters_cache [1], parameters_cache [2], parameters_cache [3], parameters_cache [4], arguments_cache[1], arguments_cache[2], arguments_cache[3])
 		if (not okey) then
 			_detalhes:Msg ("|cFFFF9900error on custom text|r:", value)
 			return 0


### PR DESCRIPTION
Allows users to write a custom text function that freely modifies data1, data2, and data3 on custom texts.