### PR TITLE
Trio fixes

### DIFF
--- a/classes/class_utility.lua
+++ b/classes/class_utility.lua
@@ -1690,7 +1690,7 @@ function atributo_misc:ToolTipBuffUptime (instancia, numero, barra)
 	local _combat_time = instancia.showing:GetCombatTime()
 	
 	for _spellid, _tabela in _pairs (minha_tabela) do
-		buffs_usados [#buffs_usados+1] = {_spellid, _tabela.uptime}
+		buffs_usados [#buffs_usados+1] = {_spellid, _tabela.uptime or 0}
 	end
 	--_table_sort (buffs_usados, Sort2Reverse)
 	_table_sort (buffs_usados, _detalhes.Sort2)

--- a/core/parser.lua
+++ b/core/parser.lua
@@ -2798,7 +2798,7 @@
 						escudo [alvo_name][spellid][who_name] = amount
 						
 						if (overheal > 0) then
-							return parser:heal (token, time, who_serial, who_name, who_flags, alvo_serial, alvo_name, alvo_flags, alvo_flags2, spellid, spellname, nil, 0, _math_ceil (overheal), 0, 0, nil, true)
+							return parser:heal (token, time, who_serial, who_name, who_flags, alvo_serial, alvo_name, alvo_flags, alvo_flags2, spellid, spellname, nil, 0, _math_ceil (overheal), 0, nil, true)
 						end
 					end
 				

--- a/frames/window_options2_sections.lua
+++ b/frames/window_options2_sections.lua
@@ -2141,7 +2141,7 @@ do
                         editInstanceSetting(currentInstance, "SetBarTextSettings", nil, nil, nil, nil, nil, nil, nil, nil, text)
                         afterUpdate()
                     end
-                    _G.DetailsWindowOptionsBarTextEditor:Open (currentInstance.row_info.textL_custom_text, callback, _G.DetailsOptionsWindow, _detalhes.instance_defaults.row_info.textL_custom_text)
+                    _G.DetailsWindowOptionsBarTextEditor:Open (currentInstance.row_info.textR_custom_text, callback, _G.DetailsOptionsWindow, _detalhes.instance_defaults.row_info.textL_custom_text)
                 end,
                 icontexture = [[Interface\GLUES\LOGIN\Glues-CheckBox-Check]],
                 --icontexcoords = {160/512, 179/512, 142/512, 162/512},


### PR DESCRIPTION
Buff Uptime display's tooltip was erroring if a buff had a nil uptime

If a shield was refreshed before it expired, the wasted shield was being sent as a negative critical instead of wasted shield. Making shields look worse, and making healing logs drift from WCL.

When editing Custom Right Text, it was autofilling the editor with the current Custom Left Text, instead of the right, so you couldn't make small changes.