### PR TITLE
Ignore Fated Affix Chaotic Essence

### DIFF
--- a/core/parser.lua
+++ b/core/parser.lua
@@ -297,6 +297,8 @@
 		[169429] = true,
 		[169428] = true,
 		[169430] = true,
+		
+		[189706] = true, --Chaotic Essence from Fated Affix --Remove on 10.0
 	}
 
 	local ignored_npcids = {}


### PR DESCRIPTION
The Chaotic Essence fated affix spawns an orb that you click on.

When you do, it becomes hostile and spawns 2 small adds (Chaotic Motes). The small adds double when killed, and the big add does nothing. Damaging the Chaotic Essence does not provide any buffs/throughput to the raid. WCL already ignores it on logs.