### PR TITLE
White box fix 2

### DIFF
--- a/classes/class_instance.lua
+++ b/classes/class_instance.lua
@@ -1525,14 +1525,14 @@ function _detalhes:RestauraJanela(index, temp, load_only)
 		self.rows_created = 0
 		self.rows_showing = 0
 		self.rows_max = 50
-		self.rows_fit_in_window = nil
 		self.largura_scroll = 26
 		self.bar_mod = 0
 		self.bgdisplay_loc = 0
 		self.last_modo = self.last_modo or modo_grupo
 		self.cached_bar_width = self.cached_bar_width or 0
 		self.row_height = self.row_info.height + self.row_info.space.between
-
+		self.rows_fit_in_window = _math_floor (self.posicao[self.mostrando].h / self.row_height)
+		
 	--> create frames
 		local isLocked = self.isLocked
 		local _baseframe, _bgframe, _bgframe_display, _scrollframe = gump:CriaJanelaPrincipal (self.meu_id, self)
@@ -1606,7 +1606,12 @@ function _detalhes:RestauraJanela(index, temp, load_only)
 		else
 			self.mostrando = "normal"
 		end
-
+		
+		if (not self.skin_loaded) then
+			print ("|cFFFF2222Details!: Skin for a window wasn't loaded correctly! Resetting window skin to default.")
+			self.skin = "no skin"
+			self:ChangeSkin(_detalhes.default_skin_to_use)
+		end
 	--> internal stuff
 		self.oldwith = self.baseframe:GetWidth()
 

--- a/classes/include_instance.lua
+++ b/classes/include_instance.lua
@@ -110,6 +110,7 @@ _detalhes.instance_defaults = {
 	--skin
 		skin = _detalhes.default_skin_to_use,
 		skin_custom = "",
+		skin_loaded = false,
 	--scale
 		window_scale = 1.0,
 		libwindow = {},

--- a/frames/window_main.lua
+++ b/frames/window_main.lua
@@ -7426,6 +7426,7 @@ function Details:ChangeSkin(skin_name)
 	end
 	
 	self:UpdateClickThrough()
+	self.skin_loaded = true
 end
 
 --update the window click through state


### PR DESCRIPTION
Users were getting a white box window due to a skin not being applied after loading instance_defaults

Added a 'skin loaded' value into instance_defaults. Set to true after a skin is applied.

In RestauraJanela, make sure rows_fit_in_window is set correctly, and if skin isn't loaded, then set the skin to default.

A cleaner fix than #343 imo.

This change will also retroactively fix all whiteboxes, even those created before this fix. #343 did not