### PR TITLE
Update SpecSpellList to WotLK standard

### DIFF
--- a/functions/spells.lua
+++ b/functions/spells.lua
@@ -12,188 +12,332 @@ do
 		_detalhes.SpecSpellList = { --~spec
 
 			-- Balance Druid:
-			[33831] 		= 	102, -- force of nature
-			[24858] 		= 	102, -- moonkin form
+			[33831] 		= 	102, -- Force of Nature
+			[24858] 		= 	102, -- Moonkin Form
+			[50516]			= 	102, -- Typhoon (rank 1)
+			[53223]			=	102, -- Typhoon (rank 2)
+			[53225] 		=	102, -- Typhoon (rank 3)
+			[53226] 		= 	102, -- Typhoon (rank 4)
+			[61384] 		= 	102, -- Typhoon (rank 5)
+			[48505] 		=	102, -- Starfall (rank 1)
+			[53199] 		=	102, -- Starfall (rank 2)
+			[53200] 		=	102, -- Starfall (rank 3)
+			[53201] 		= 	102, -- Starfall (rank 4)
 
-			-- Feral 		Druid:
-			[33983] 		= 	103, -- mangle cat
-			[33982] 		= 	103, -- mangle cat
-			[33876] 		= 	103, -- mangle cat
-
-			-- Guardian Druid:
-			[33986] 		= 	104, -- mangle bear
-			[33987] 		= 	104, -- mangle bear
-			[33878] 		= 	104, -- mangle bear
+			-- Feral DPS (Cat):
+			[33876] 		= 	103, -- Mangle Cat (rank 1)
+			[33982]			=	103, -- Mangle Cat (rank 2)
+			[33983]			= 	103, -- Mangle Cat (rank 3)
+			[48565]			=	103, -- Mangle Cat (rank 4)
+			[48566]			=	103, -- Mangle Cat (rank 5)
 			
+			-- Feral Tank (Bear) / Guardian Druid:
+			[33878] 		= 	104, -- Mangle Bear (rank 1)
+			[33986] 		= 	104, -- Mangle Bear (rank 2)
+			[33987] 		= 	104, -- Mangle Bear (rank 3)
+			[48563]			= 	104, -- Mangle Bear (rank 4)
+			[48564]			= 	104, -- Mangle Bear (rank 5)
+						
 			-- Restoration Druid:
-			[33891] 		= 		105, -- tree of life
-			[18562] 		= 		105, -- swiftmend
+			[33891] 		= 	105, -- Tree of Life
+			[18562] 		= 	105, -- Swiftmend
+			[48438]			=	105, -- Wild Growth (rank 1)
+			[53248]			=	105, -- Wild Growth (rank 2)
+			[53249]			= 	105, -- Wild Growth (rank 3)
+			[53251]			=	105, -- Wild Growth (rank 4)
 
 			-- Beast Mastery Hunter:
-			[19574]        =       253,    --      bestial wrath
+			[19574]			=	253, -- Bestial Wrath
+			[53257]			=	253, -- Cobra Strikes
 			
 			-- Marksmanship Hunter:
-			[34490] =       254,    --    silencing shot
-			[19506] =       254,    --    trueshot aura
-			[20905] =       254,    --    trueshot aura
-			[20906] =       254,    --    trueshot aura
-			[27066] =       254,    --    trueshot aura
+			[34490]			=	254, -- Silecing Shot
+			[19506]			=	254, -- Trueshot Aura
+			[53209]			=	254, -- Chimera Shot
 			
 			-- Survival Hunter:
-			[23989]        =       255,    --   readiness
-			[19386]        =       255,    --   wyvern sting
-			[24132]        =       255,    --   wyvern sting
-			[24133]        =       255,    --   wyvern sting
-			[27068]        =       255,    --   wyvern sting
+			[19386]			=	255, -- Wyvern Sting (rank 1)
+			[24132]			=	255, -- Wyvern Sting (rank 2)
+			[24133]			=	255, -- Wyvern Sting (rank 3)
+			[27068]			=	255, -- Wyvern Sting (rank 4)
+			[49011]			=	255, -- Wyvern Sting (rank 5)
+			[49012]			=	255, -- Wyvern Sting (rank 6)
+			[3674]			= 	255, -- Black Arrow (rank 1)
+			[63668]			=	255, -- Black Arrow (rank 2)
+			[63669]			= 	255, -- Black Arrow (rank 3)
+			[63670]			=	255, -- Black Arrow (rank 4)
+			[63671]			=	255, -- Black Arrow (rank 5)
+			[63672]			=	255, -- Black Arrow (rank 6)
+			[53301]			=	255, -- Explosive Shot (rank 1)
+			[60051]			=	255, -- Explosive Shot (rank 2)
+			[60052]			=	255, -- Explosive Shot (rank 3)
+			[60053]			=	255, -- Explosive Shot (rank 4)
 
 			-- Arcane Mage:
-			[31589]        =       62,     --      slow
-			[12042]        =       62,     --      arcane power
-			[12043]        =       62,     --      presence of mind
+			[12043]			=	62, -- Presence of Mind
+			[12042]			=	62, -- Arcane Power
+			[31589]			=	62, -- Slow
+			[44425]			=	62, -- Arcane Barrage (rank 1)
+			[44780]			=	62, -- Arcane Barrage (rank 2)
+			[44781]			=	62, -- Arcane Barrage (rank 3)			
 
 			-- Fire Mage:
-			[31661]        =       63,     --      dragon's breath
-			[33041]        =       63,     --      dragon's breath
-			[33042]        =       63,     --      dragon's breath
-			[33043]        =       63,     --      dragon's breath
-			[28682]        =       63,     --      combustion
-			[27133]        =       63,     --      blast wave
-			[11113]        =       63,     --      blast wave
-			[13018]        =       63,     --      blast wave
-			[13019]        =       63,     --      blast wave
-			[13020]        =       63,     --      blast wave
-			[13021]        =       63,     --      blast wave
-			[33933]        =       63,     --      blast wave
+			[28682]			=	63, -- Combustion
+			[48108]			=	63, -- Hot Streak
+			[31661]			=	63, -- Dragon's Breath (rank 1)
+			[33041]			=	63, -- Dragon's Breath (rank 2)
+			[33042]			=	63, -- Dragon's Breath (rank 3)
+			[33043]			=	63, -- Dragon's Breath (rank 4)
+			[42949]			=	63, -- Dragon's Breath (rank 5)
+			[42950]			=	63, -- Dragon's Breath (rank 6)
+			[44457]			=	63, -- Living Bomb (rank 1)
+			[55359]			=	63, -- Living Bomb (rank 2)
+			[55360]			=	63, -- Living Bomb (rank 3)
 
 			-- Frost Mage:
-			[31687]        =       64,     --      summon water elemental
-			[11426]        =       64,     --      ice barrier
-			[13032]        =       64,     --      ice barrier
-			[13033]        =       64,     --      ice barrier
-			[27134]        =       64,     --      ice barrier
-			[33405]        =       64,     --      ice barrier
-			[11958]        =       64,     --      cold snap
-
+			[11426]			=	64, -- Ice Barrier (rank 1)
+			[13031]			=	64, -- Ice Barrier (rank 2)
+			[13032]			=	64, -- Ice Barrier (rank 3)
+			[13033]			=	64, -- Ice Barrier (rank 4)
+			[27134]			=	64, -- Ice Barrier (rank 5)
+			[33405]			=	64, -- Ice Barrier (rank 6)
+			[43038]			=	64, -- Ice Barrier (rank 7)
+			[43039]			=	64, -- Ice Barrier (rank 8)
+			[44544]			=	64, -- Fingers of Frost
+			[57761]			=	64, -- Fireball! (Brain Freeze talent)
+			[31687]			=	64, -- Summon Water Elemental
+			[44572]			=	64, -- Deep Freeze
+	
 			-- Holy Paladin:
-			[31842]        =       65,     --      divine illumination
-			[20473]        =       65,     --      holy shock
-			[20929]        =       65,     --      holy shock
-			[20930]        =       65,     --      holy shock
-			[27174]        =       65,     --      holy shock
-			[33072]        =       65,     --      holy shock
+			[20473]			=	65, -- Holy Shock (rank 1)
+			[20929]			=	65, -- Holy Shock (rank 2)
+			[20930]			=	65, -- Holy Shock (rank 3)
+			[27174]			=	65, -- Holy Shock (rank 4)
+			[33072]			=	65, -- Holy Shock (rank 5)
+			[48824]			=	65, -- Holy Shock (rank 6)
+			[48825]			=	65, -- Holy Shock (rank 7)
+			[31842]			=	65, -- Divine Illumination
+			[53563]			=	65, -- Beacon of Light
 
 			-- Protection Paladin:
-			[31935] =       66,     --      avengers shield
-			[32699] =       66,     --      avengers shield
-			[32700] =       66,     --      avengers shield
-			[20925] =       66,     --      holy shield
-			[20927] =       66,     --      holy shield
-			[20928] =       66,     --      holy shield
-			[27179] =       66,     --      holy shield
-
+			[20925]			=	66, -- Holy Shield (rank 1)
+			[20927]			=	66, -- Holy Shield (rank 2)
+			[20928]			=	66, -- Holy Shield (rank 3)
+			[27179]			=	66, -- Holy Shield (rank 4)
+			[48951]			=	66, -- Holy Shield (rank 5)
+			[48952]			=	66, -- Holy Shield (rank 6)
+			[31935]			=	66, -- Avenger's Shield (rank 1)
+			[32699]			=	66, -- Avenger's Shield (rank 2)
+			[32700]			=	66, -- Avenger's Shield (rank 3)
+			[48826]			=	66, -- Avenger's Shield (rank 4)
+			[48827]			=	66, -- Avenger's Shield (rank 5)
+			[53595]			=	66, -- Hammer of the Righteous
+			
 			-- Retribution Paladin:
-			[35395]        =       70,     --      crusader strike
-			[20066]        =       70,     --      repentance
+			[53489]			=	70, -- The Art of War (rank 1)
+			[59578]			=	70, -- The Art of War (rank 2)
+			[20066]			=	70, -- Repentance
+			[35395]			=	70, -- Crusader Strike
+			[53385]			=	70, -- Divine Storm
 
 			-- Discipline Priest:
-			[33206] =       256,    --      pain suppression
-			[10060] =       256,    --      power infusion
-
+			[10060]			=	256, -- Power Infusion
+			[33206]			=	256, -- Pain Suppression
+			[47540]			=	256, -- Penance (rank 1)
+			[53005]			=	256, -- Penance (rank 2)
+			[53006]			=	256, -- Penance (rank 3)
+			[53007]			=	256, -- Penance (rank 4)
+			
 			-- Holy Priest:
-			[34861]        =       257,    --    circle of healing
-			[34863]        =       257,    --    circle of healing
-			[34864]        =       257,    --    circle of healing
-			[34865]        =       257,    --    circle of healing
-			[34866]        =       257,    --    circle of healing
-			[724]        =       257,    --    lightwell
-			[27870]        =       257,    --    lightwell
-			[27871]        =       257,    --    lightwell
-			[27875]        =       257,    --    lightwell
-			[20711]        =       257,    --    spirit of redemption
-
+			[20711]			=	257, -- Spirit of Redemption
+			[724]			=	257, -- Lightwell (rank 1)
+			[27870]			=	257, -- Lightwell (rank 2)
+			[27871]			=	257, -- Lightwell (rank 3)
+			[27875]			=	257, -- Lightwell (rank 4)
+			[48086]			=	257, -- Lightwell (rank 5)
+			[48087]			=	257, -- Lightwell (rank 6)
+			[34861]			=	257, -- Circle of Healing (rank 1)
+			[34863]			=	257, -- Circle of Healing (rank 2)
+			[34864]			=	257, -- Circle of Healing (rank 3)
+			[34865]			=	257, -- Circle of Healing (rank 4)
+			[34866]			=	257, -- Circle of Healing (rank 5)
+			[48088]			=	257, -- Circle of Healing (rank 6)
+			[48089]			=	257, -- Circle of Healing (rank 7)
+			[47788]			=	257, -- Guardian Spirit
+			
 			-- Shadow Priest:
-			[34914]        =       258,    --      vampiric touch
-			[34916]        =       258,    --      vampiric touch
-			[34917]        =       258,    --      vampiric touch
-			[15473]        =       258,    --      shadowform
-			[15286]        =       258,    --      vampiric embrace
+			[15286]			=	258, -- Vampiric Embrace
+			[15473]			=	258, -- Shadowform
+			[34914]			=	258, -- Vampiric Touch (rank 1)
+			[34916]			=	258, -- Vampiric Touch (rank 2)
+			[34917]			=	258, -- Vampiric Touch (rank 3)
+			[48159]			=	258, -- Vampiric Touch (rank 4)
+			[48160]			=	258, -- Vampiric Touch (rank 5)
+			[47585]			=	258, -- Dispersion			
 
 			-- Assassination Rogue:
-			[1329]        =       259,    --      mutilate
-			[34411]        =       259,    --      mutilate
-			[34412]        =       259,    --      mutilate
-			[34413]        =       259,    --      mutilate
+			[58427]			=	259, -- Overkill
+			[1329]			=	259, -- Mutilate (rank 1)
+			[34411]			=	259, -- Mutilate (rank 2)
+			[34412]			=	259, -- Mutilate (rank 3)
+			[34413]			=	259, -- Mutilate (rank 4)
+			[48663]			=	259, -- Mutilate (rank 5)
+			[48666]			=	259, -- Mutilate (rank 6)
+			[52914]			=	259, -- Turn the Tables (rank 1)
+			[52915]			=	259, -- Turn the Tables (rank 2)
+			[52910]			=	259, -- Turn the Tables (rank 3)
+			[51662]			=	259, -- Hunger For Blood
 
-			-- Outlaw (Combat) Rogue:
-			[13750]        =       260,    --      adrenaline rush
+			-- Combat Rogue (Outlaw Rogue):
+			[13750]			=	260, -- Adrenaline Rush
+			[51690]			=	260, -- Killing Spree
+			[58684]			=	260, -- Savage Combat (rank 1)
+			[58683]			=	260, -- Savage Combat (rank 2)
 
 			-- Subtlety Rogue:
-			[36554]        =       261,    --      shadowstep
-			[14183]        =       261,    --      premeditation
-
+			[14183]			=	261, -- Premeditation
+			[36554]			=	261, -- Shadowstep
+			[51713]			=	261, -- Shadow Dance
+			
 			-- Elemental Shaman:
-			[30706] = 262, -- totem of wrath
-			[16166] = 262, -- elemental mastery
+			[16166]			=	262, -- Elemental Mastery
+			[30706]			=	262, -- Totem of Wrath (rank 1)
+			[57720]			=	262, -- Totem of Wrath (rank 2)
+			[57721]			=	262, -- Totem of Wrath (rank 3)
+			[57722]			=	262, -- Totem of Wrath (rank 4)
+			[51490]			=	262, -- Thunderstorm (rank 1)
+			[59156]			=	262, -- Thunderstorm (rank 2)
+			[59158]			=	262, -- Thunderstorm (rank 3)
+			[59159]			=	262, -- Thunderstorm (rank 4)
 
 			-- Enhancement Shaman:
-			[30823] = 263, -- shamanistic rage
-			[17364] = 263, -- storm strike
+			[17364]			=	263, -- Stormstrike
+			[60103]			=	263, -- Lava Lash
+			[30823]			=	263, -- Shamanistic Rage
+			[53817]			=	263, -- Maelstrom Weapon
+			[51533]			=	263, -- Feral Spirit
 
 			-- Restoration Shaman:
-			[974] = 264, -- earth shield
-			[32593] = 264, -- earth shield
-			[32594] = 264, -- earth shield
-			[16190] = 264, -- mana tide totem
+			[16190]			=	264, -- Mana Tide Totem
+			[51886]			=	264, -- Cleanse Spirit
+			[974]			=	264, -- Earth Shield (rank 1)
+			[32593]			=	264, -- Earth Shield (rank 2)
+			[32594]			=	264, -- Earth Shield (rank 3)
+			[49283]			=	264, -- Earth Shield (rank 4)
+			[49284]			=	264, -- Earth Shield (rank 5)
+			[61295]			=	264, -- Riptide (rank 1)
+			[61299]			=	264, -- Riptide (rank 2)
+			[61300]			=	264, -- Riptide (rank 3)
+			[61301]			=	264, -- Riptide (rank 4)
 
-			-- Affliction :
-			[30108]        =       265,    --    unstable affliction
-			[30404]        =       265,    --    unstable affliction
-			[30405]        =       265,    --    unstable affliction
-			[18220]			=		265,   --    dark pact
-			[18937]			=		265,   --    dark pact
-			[18938]			=		265,   --    dark pact
-			[27265]			=		265,   --    dark pact
+			-- Affliction Warlock:
+			[30108]			=	265, -- Unstable Affliction (rank 1)
+			[30404]			=	265, -- Unstable Affliction (rank 2)
+			[30405]			=	265, -- Unstable Affliction (rank 3)
+			[47841]			=	265, -- Unstable Affliction (rank 4)
+			[47843]			=	265, -- Unstable Affliction (rank 5)
+			[18220]			=	265, -- Dark Pact (rank 1)
+			[18937]			=	265, -- Dark Pact (rank 2)
+			[18938]			=	265, -- Dark Pact (rank 3)
+			[27265]			=	265, -- Dark Pact (rank 4)
+			[59092]			=	265, -- Dark Pact (rank 5)
+			[48181]			=	265, -- Haunt (rank 1)
+			[59161]			=	265, -- Haunt (rank 2)
+			[59163]			=	265, -- Haunt (rank 3)
+			[59164]			=	265, -- Haunt (rank 4)
 
-			--  Demonology Warlock:
-			[30146]        =       266,    --      summon felguard
-			[19028]        =       266,    --      soul link
+			-- Demonology Warlock:
+			[30146]			=	266, -- Summon Felguard
+			-- [48090]			=	266, -- Demonic Pact -- Need confirmation for WotLK Classic whether this is the right buff
+			[47383]			=	266, -- Molten Core (rank 1)
+			[71162]			=	266, -- Molten Core (rank 2)
+			[71165]			=	266, -- Molten Core (rank 3)
+			[63165]			=	266, -- Decimation (rank 1)
+			[63167]			=	266, -- Decimation (rank 2)
+			[47241]			=	266, -- Metamorphosis
+			
+			-- Destruction Warlock:
+			[17962]			=	267, -- Conflagrate
+			[30283]			=	267, -- Shadowfury (rank 1)
+			[30413]			=	267, -- Shadowfury (rank 2)
+			[30414]			=	267, -- Shadowfury (rank 3)
+			[47846]			=	267, -- Shadowfury (rank 4)
+			[47847]			=	267, -- Shadowfury (rank 5)
+			[50796]			=	267, -- Chaos Bolt (rank 1)
+			[59170]			=	267, -- Chaos Bolt (rank 2)
+			[59171]			=	267, -- Chaos Bolt (rank 3)
+			[59172]			=	267, -- Chaos Bolt (rank 4)
 
-			--  Destruction Warlock:
-			[30283]        =       267,    --      shadowfury
-			[30413]        =       267,    --      shadowfury
-			[30414]        =       267,    --      shadowfury
+			-- Arms Warrior:
+			[46856]			=	71, -- Trauma (rank 1)
+			[46857]			=	71, -- Trauma (rank 2)
+			[12294]			=	71, -- Mortal Strike (rank 1)
+			[21551]			=	71, -- Mortal Strike (rank 2)
+			[21552]			=	71, -- Mortal Strike (rank 3)
+			[21553]			=	71, -- Mortal Strike (rank 4)
+			[25248]			=	71, -- Mortal Strike (rank 5)
+			[30330]			=	71, -- Mortal Strike (rank 6)
+			[47485]			=	71, -- Mortal Strike (rank 7)
+			[47486]			=	71, -- Mortal Strike (rank 8)
+			[29623]			=	71, -- Endless Rage
+			[46924]			=	71, -- Bladestorm
 
-			--  Arms Warrior:
-			[29623]   =       71,     --      endless rage
-			[12294]   =       71,     --      mortal strike
-			[30330]   =       71,     --      mortal strike
-			[25248]   =       71,     --      mortal strike
-			[27580]   =       71,     --      mortal strike
-			[21553]   =       71,     --      mortal strike
-			[21552]   =       71,     --      mortal strike
-			[21551]   =       71,     --      mortal strike
+			-- Fury Warrior:
+			[29801]			=	72, -- Rampage		
+			[23881]			=	72, -- Bloodthirst
+			
+			-- Protection Warrior:
+			[50720]			=	73, -- Vigilance
+			[20243]			=	73, -- Devastate (rank 1)
+			[30016]			=	73, -- Devastate (rank 2)
+			[30022]			=	73, -- Devastate (rank 3)
+			[47497]			=	73, -- Devastate (rank 4)
+			[47498]			=	73, -- Devastate (rank 5)
+			[50227]			=	73, -- Sword and Board
+			[46968]			=	73, -- Shockwave
 
-			--  Fury Warrior:
-			[30033] =       72,     --  rampage
-			[29801] =       72,     --  rampage
-			[30030] =       72,     --  rampage
-			[23881] =       72,     --  bloodthirst
-			[23892] =       72,     --  bloodthirst
-			[23893] =       72,     --  bloodthirst
-			[23894] =       72,     --  bloodthirst
-			[25251] =       72,     --  bloodthirst
-			[30335] =       72,     --  bloodthirst
+			-- Blood Death Knight:
+			[53137]			=	250, -- Abomination's Might (rank 1)
+			[53138]			=	250, -- Abomination's Might (rank 2)
+			[49016]			=	250, -- Hysteria
+			[55050]			=	250, -- Heart Strike (rank 1)
+			[55258]			=	250, -- Heart Strike (rank 2)
+			[55259]			=	250, -- Heart Strike (rank 3)
+			[55260]			=	250, -- Heart Strike (rank 4)
+			[55261]			=	250, -- Heart Strike (rank 5)
+			[55262]			=	250, -- Heart Strike (rank 6)
+			[49028]			=	250, -- Dancing Rune Weapon
 
-			--  Protection Warrior:
-			[20243]        =       73,     --     devastate
-			[30022]        =       73,     --     devastate
-			[30016]        =       73,     --     devastate
-			[23922]        =       73,     --     shield slam
-			[23923]        =       73,     --     shield slam
-			[23924]        =       73,     --     shield slam
-			[23925]        =       73,     --     shield slam
-			[25258]        =       73,     --     shield slam
-			[30356]        =       73,     --     shield slam
+			-- Frost Death Knight:
+			[49203]			=	251, -- Hungering Cold
+			[51271]			=	251, -- Unbreakable Armor
+			[49143]			=	251, -- Frost Strike (rank 1)
+			[51416]			=	251, -- Frost Strike (rank 2)
+			[51417]			=	251, -- Frost Strike (rank 3)
+			[51418]			=	251, -- Frost Strike (rank 4)
+			[51419]			=	251, -- Frost Strike (rank 5)
+			[55268]			=	251, -- Frost Strike (rank 6)
+			[49184]			=	251, -- Howling Blast (rank 1)
+			[51409]			=	251, -- Howling Blast (rank 2)
+			[51410]			=	251, -- Howling Blast (rank 3)
+			[51411]			=	251, -- Howling Blast (rank 4)
+
+			-- Unholy Death Knight:
+			[51052]			=	252, -- Anti-Magic Zone
+			[63583]			=	252, -- Desolation (rank 1)
+			[66800]			=	252, -- Desolation (rank 2)
+			[66801]			=	252, -- Desolation (rank 3)
+			[66802]			=	252, -- Desolation (rank 4)
+			[66803]			=	252, -- Desolation (rank 5)
+			[49222]			=	252, -- Bone Shield
+			[51726]			=	252, -- Ebon Plague (rank 1)
+			[51734]			=	252, -- Ebon Plague (rank 2)
+			[51735]			=	252, -- Ebon Plague (rank 3)
+			[55090]			=	252, -- Scourge Strike (rank 1)
+			[55265]			=	252, -- Scourge Strike (rank 2)
+			[55270]			=	252, -- Scourge Strike (rank 3)
+			[55271]			=	252, -- Scourge Strike (rank 4)
+			[49206]			=	252, -- Summon Gargoyle
 		}
 
 	else


### PR DESCRIPTION
Referencing issue #350
Until/if Blizzard decides to fix NotifyInspect and CanInspect spamming out of range errors I guess checking spells done by spec is the only non-messy way to get unit specs properly for WotLK Classic.

Note that I didn't add anything to bear tank except new ranks of mangle since it's hard to say if feral is a tank without checking his gear or talents (ignoring dps). Also with bearweaving being a thing now it's even more unreliable.

Also for demo lock if he is speccing hybrid with conflag + molten core and decimation talents then I guess you would want to count him as destro? I will leave that decision up to you whether to keep these spells in demo or not.