### PR TITLE
Use GetServerExpansionLevel instead

### DIFF
--- a/Libs/LibOpenRaid/LibOpenRaid.lua
+++ b/Libs/LibOpenRaid/LibOpenRaid.lua
@@ -54,7 +54,7 @@ if (WOW_PROJECT_ID ~= WOW_PROJECT_MAINLINE and not IsDragonflight()) then
 end
 
 local major = "LibOpenRaid-1.0"
-local CONST_LIB_VERSION = 52
+local CONST_LIB_VERSION = 53
 LIB_OPEN_RAID_CAN_LOAD = false
 
 --declae the library within the LibStub

--- a/Libs/LibOpenRaid/ThingsToMantain.lua
+++ b/Libs/LibOpenRaid/ThingsToMantain.lua
@@ -5,7 +5,7 @@ if (not LIB_OPEN_RAID_CAN_LOAD) then
 	return
 end
 
-local expansionId = GetExpansionLevel()
+local expansionId = GetServerExpansionLevel()
 
 --localization
 local gameLanguage = GetLocale()


### PR DESCRIPTION
For accounts that haven't purchased the most recent expansion (BFA accounts on SL, or more likely SL accounts that haven't bought DF, when DF comes out), will have their GetExpansionLevel be one lower. Changed to use GetServerExpansionLevel instead. 

https://wowpedia.fandom.com/wiki/API_GetExpansionLevel