### PR TITLE
class_custom missing self reference in timer

### DIFF
--- a/classes/class_custom.lua
+++ b/classes/class_custom.lua
@@ -892,7 +892,7 @@
 				end
 				if (newActor.classe == "UNGROUPPLAYER") then
 					--atributo_custom:ScheduleTimer ("UpdateClass", 5, {newActor = newActor, actor = actor})
-					Details.Schedules.NewTimer(5, atributo_custom.UpdateClass, {new_actor = newActor, actor = actor})
+					Details.Schedules.NewTimer(5, atributo_custom.UpdateClass, self, {new_actor = newActor, actor = actor})
 				end
 			end
 


### PR DESCRIPTION
A timer call to UpdateClass wasn't passing in the self reference, thus the parameter "actors" was not being filled since the passed in data was being routed to "self"