### PR TITLE
Lifebloom's bloom can now be tracked in WotLK

### DIFF
--- a/core/parser.lua
+++ b/core/parser.lua
@@ -2200,6 +2200,14 @@
 			cura_efetiva = cura_efetiva + amount - overhealing
 		end
 
+		if (isTBC) then
+			--life bloom explosion (second part of the heal)
+			if (spellid == SPELLID_DRUID_LIFEBLOOM_HEAL) then
+				TBC_LifeBloomLatestHeal = cura_efetiva
+				return
+			end
+		end
+
 		if (isTBC or isWOTLK) then
 			--earth shield
 			if (spellid == SPELLID_SHAMAN_EARTHSHIELD_HEAL) then
@@ -2216,11 +2224,6 @@
 					who_serial, who_name, who_flags = unpack(sourceData)
 					TBC_PrayerOfMendingCache[who_name] = nil
 				end
-
-			--life bloom explosion (second part of the heal)
-			elseif (spellid == SPELLID_DRUID_LIFEBLOOM_HEAL) then
-				TBC_LifeBloomLatestHeal = cura_efetiva
-				return
 
 			elseif (spellid == 27163 and false) then --Judgement of Light (paladin) --disabled on 25 September 2022
 				--check if the hit was landed in the same cleu tick


### PR DESCRIPTION
I do not know how Lifebloom works in TBC. However, in WotLK, the final bloom effect has two parts:
```
10/14 13:56:47.285  SPELL_AURA_REMOVED,Player-4725-031D2613,"Caster-Redacted",0x511,0x0,Player-4725-03339302,"Target-Redacted",0x518,0x0,48451,"Lifebloom",0x8,BUFF
10/14 13:56:47.285  SPELL_HEAL,Player-4725-031D2613,"Caster-Redacted",0x511,0x0,Player-4725-03339302,"Target-Redacted",0x518,0x0,33778,"Lifebloom",0x8,0000000000000000,0000000000000000,0,0,0,0,0,-1,0,0,0,0.00,0.00,1453,0.0000,0,7580,7580,7580,0,nil
```

The previous code does the following logic for detecting Lifebloom's bloom:
- Cache the heal value from `SPELLID_DRUID_LIFEBLOOM_HEAL` (id: 33778)
- Listen for `SPELLID_DRUID_LIFEBLOOM_BUFF` (id: 33763) being removed
- Award the cached heal value

I assume all of that is necessary for TBC, but it is not necessary for WotLK. In WotLK, Lifebloom matches retail's behavior, so I have changed the code to not give lifebloom any special treatment in WotLK.