### PR TITLE
Fixed a spelling error in Details_Vanguard.lua

### DIFF
--- a/plugins/Details_Vanguard/Details_Vanguard.lua
+++ b/plugins/Details_Vanguard/Details_Vanguard.lua
@@ -984,8 +984,8 @@ local build_options_panel = function()
 			min = 10,
 			max = 50,
 			step = 1,
-			--desc = "Inc Damage Heigth",
-			name = "Incoming Damage Heigth",
+			--desc = "Inc Damage Height",
+			name = "Incoming Damage Height",
 		},
 		{type = "blank"},
 


### PR DESCRIPTION
I corrected the spelling of the word 'Height' as it had accidentally been written as 'Heigth'.