### PR TITLE
Add the Version value to Wrath toc file for /details

### DIFF
--- a/Details_Wrath.toc
+++ b/Details_Wrath.toc
@@ -4,6 +4,7 @@
 ## SavedVariables: _detalhes_global
 ## SavedVariablesPerCharacter: _detalhes_database
 ## OptionalDeps: Ace3, LibSharedMedia-3.0, LibWindow-1.1, LibDBIcon-1.0, NickTag-1.0, LibDataBroker-1.1, LibItemUpgradeInfo-1.0, LibGroupInSpecT-1.1, LibCompress, LibGraph-2.0
+## Version: #@project-version@
 #@no-lib-strip@
 Libs\libs.xml
 #@end-no-lib-strip@


### PR DESCRIPTION
This should (If I understand the builder correctly) auto fill the Curseforge Version Number into the Wrath TOC file to stop /details from erroring on Wrath.