### PR TITLE
Use Wrath with Retail API check for gradients

### DIFF
--- a/Libs/DF/picture.lua
+++ b/Libs/DF/picture.lua
@@ -300,7 +300,7 @@ detailsFramework:Mixin(ImageMetaFunctions, detailsFramework.ScriptHookMixin)
 		if (texture) then
 			if (type(texture) == "table") then
 				if (texture.gradient) then
-					if (detailsFramework.IsDragonflight() or ImageObject.image.SetGradient) then
+					if (detailsFramework.IsDragonflight() or detailsFramework.IsWotLKWowWithRetailAPI()) then
 						ImageObject.image:SetColorTexture(1, 1, 1, 1)
 						local fromColor = detailsFramework:FormatColor("tablemembers", texture.fromColor)
 						local toColor = detailsFramework:FormatColor("tablemembers", texture.toColor)


### PR DESCRIPTION
Wrath does now have SetGradient, but I believe it is the 'old' version that does not accept the colormixins. Adding this check makes the fallback happen again which will correctly apply the gradient on current wrath.