### PR TITLE
Fire Elemental on Wrath fix

### DIFF
--- a/core/parser.lua
+++ b/core/parser.lua
@@ -2116,6 +2116,25 @@
 			--alvo_name = "Fire Spirit"
 		end
 
+		--If fire elemental totem on Wrath, then ignore the summon of the fire elemental totem itself and instead create the Greater Fire Elemental early.
+		--Greater Fire Elemental and Fire Elemental Totem have the same serial besides the npc id.
+		--There are cases where the Greater Fire Elemental could attack and the SWING_DAMAGE event happens before the spell_summon for it. Same frame.
+		--[[12/14 21:14:44.545  SPELL_SUMMON,Player-4384-03852552,"Toekruh-Mankrik",0x512,0x0,Creature-0-4391-615-3107-15439-00001A8313,"Fire Elemental Totem",0xa28,0x0,2894,"Fire Elemental Totem",0x1
+			12/14 21:14:44.545  SWING_DAMAGE,Creature-0-4391-615-3107-15438-00001A8313,"Greater Fire Elemental",0x2112,0x0,Creature-0-4391-615-3107-28860-00001A8258,"Sartharion",0xa48,0x0,Creature-0-4391-615-3107-15438-00001A8313,Creature-0-4391-615-3107-15439-00001A8313,4274,4274,0,0,0,-1,0,0,0,3261.68,530.04,155,3.3324,208,188,187,-1,4,0,0,0,nil,nil,nil
+			12/14 21:14:44.545  SPELL_CAST_SUCCESS,Creature-0-4391-615-3107-15438-00001A8313,"Greater Fire Elemental",0x2112,0x0,Creature-0-4391-615-3107-28860-00001A8258,"Sartharion",0xa48,0x0,57984,"Fire Blast",0x4,Creature-0-4391-615-3107-15438-00001A8313,Creature-0-4391-615-3107-15439-00001A8313,4274,4274,0,0,0,-1,0,0,0,3261.68,530.04,155,3.3324,208
+			12/14 21:14:44.545  SPELL_CAST_SUCCESS,Creature-0-4391-615-3107-15439-00001A8313,"Fire Elemental Totem",0x2112,0x0,0000000000000000,nil,0x80000000,0x80000000,32982,"Fire Elemental Totem",0x1,Creature-0-4391-615-3107-15439-00001A8313,Player-4384-03852552,3888,3888,0,0,0,-1,0,0,0,3257.01,531.82,155,5.1330,208
+			12/14 21:14:44.545  SPELL_SUMMON,Creature-0-4391-615-3107-15439-00001A8313,"Fire Elemental Totem",0x2112,0x0,Creature-0-4391-615-3107-15438-00001A8313,"Greater Fire Elemental",0x2112,0x0,32982,"Fire Elemental Totem",0x1
+			]]
+		if(isWOTLK) then
+			if(npcId == 15439) then
+				alvo_serial = alvo_serial:gsub("-15439-", "-15438-")
+				alvo_name = "Greater Fire Elemental"
+				--Don't need to set the pet flags since it is a guardian and will always hit the 2nd part of tabela_pets:Adicionar
+			elseif (npcId == 15438) then
+				return
+			end
+		end
+
 		--pet summon another pet
 		local sou_pet = container_pets [who_serial]
 		if (sou_pet) then --okey, ja � um pet

--- a/core/parser.lua
+++ b/core/parser.lua
@@ -2127,9 +2127,7 @@
 			]]
 		if(isWOTLK) then
 			if(npcId == 15439) then
-				alvo_serial = alvo_serial:gsub("-15439-", "-15438-")
-				alvo_name = "Greater Fire Elemental"
-				--Don't need to set the pet flags since it is a guardian and will always hit the 2nd part of tabela_pets:Adicionar
+				_detalhes.tabela_pets:Adicionar(alvo_serial:gsub("-15439-", "-15438-"), "Greater Fire Elemental", alvo_flags, who_serial, who_name, who_flags)
 			elseif (npcId == 15438) then
 				return
 			end

--- a/core/parser.lua
+++ b/core/parser.lua
@@ -2127,7 +2127,7 @@
 			]]
 		if(isWOTLK) then
 			if(npcId == 15439) then
-				_detalhes.tabela_pets:Adicionar(alvo_serial:gsub("-15439-", "-15438-"), "Greater Fire Elemental", alvo_flags, who_serial, who_name, who_flags)
+				_detalhes.tabela_pets:Adicionar (alvo_serial:gsub("%-15439%-", "%-15438%-"), "Greater Fire Elemental", alvo_flags, who_serial, who_name, who_flags)
 			elseif (npcId == 15438) then
 				return
 			end


### PR DESCRIPTION
As stated in the comments in the commit, the Greater Fire Elemental summoned by the Fire Elemental Totem can have a SWING_DAMAGE event occur **before** the SPELL_SUMMON event for it is triggered. 
This change just looks for the totem npc id and creates the fire elemental at the same time as the totem is created, and ignores the fire elemental when it is summoned.

Code isn't fully tested as I don't have a Shaman on Wrath. Would be best fit for an Alpha release so we can have those who we know have had issues test.