### PR TITLE
Fix FF/Damage Taken breakdown to show bars and spell names.

### DIFF
--- a/classes/class_damage.lua
+++ b/classes/class_damage.lua
@@ -4307,7 +4307,7 @@ end
 
 	elseif (class) then
 		local color = Details.class_colors[class]
-		if (color) then
+		if (color and class ~= "UNKNOW") then
 			row.textura:SetStatusBarColor(unpack(color))
 		else
 			row.textura:SetStatusBarColor(1, 1, 1)

--- a/frames/window_playerbreakdown.lua
+++ b/frames/window_playerbreakdown.lua
@@ -5635,6 +5635,8 @@ local row_on_leave = function(self)
 
 	elseif (self.isAlvo) then
 		self:SetHeight(CONST_TARGET_HEIGHT)
+	elseif (self.isDetalhe) then
+		self:SetHeight(16)
 	end
 end
 
@@ -6054,13 +6056,15 @@ function gump:CriaNovaBarraInfo3 (instancia, index)
 
 	esta_barra:EnableMouse(true)
 
-	CriaTexturaBarra(esta_barra)
+	
 
 	--icone
 	esta_barra.icone = esta_barra:CreateTexture(nil, "OVERLAY")
 	esta_barra.icone:SetWidth(14)
 	esta_barra.icone:SetHeight(14)
-	esta_barra.icone:SetPoint("RIGHT", esta_barra.textura, "LEFT", 18, 0)
+	esta_barra.icone:SetPoint("LEFT", esta_barra, "LEFT", 0, 0)
+
+	CriaTexturaBarra(esta_barra)
 
 	esta_barra:SetAlpha(0.9)
 	esta_barra.icone:SetAlpha(1)


### PR DESCRIPTION
In the breakdown:

Damage taken by enemy did not show a bar as the background and foreground colors were the same. Added a check for class ~= "UNKNOW" when using class color since unknown is the same color.

The bars for infobox3 were initialized in a funky order. The bars were made, but lineText1 setPoint based on the icone, which was created after the bars were made. So lineText1 was sitting out off screen.