### PR TITLE
Don't save a SwitchBack table when leaving combat

### DIFF
--- a/classes/class_instance.lua
+++ b/classes/class_instance.lua
@@ -1705,11 +1705,11 @@ function _detalhes:CheckSwitchOnCombatEnd (nowipe, warning)
 	local got_switch = false
 
 	if (role == "DAMAGER" and self.switch_damager) then
-		self:SwitchTo (self.switch_damager)
+		self:SwitchTo (self.switch_damager, true)
 		got_switch = true
 
 	elseif (role == "HEALER" and self.switch_healer) then
-		self:SwitchTo (self.switch_healer)
+		self:SwitchTo (self.switch_healer, true)
 		got_switch = true
 
 	elseif (role == "TANK" and self.switch_tank) then


### PR DESCRIPTION
When using the Automation tab's Switch By Role functionality, if you're using both In Combat and Out of Combat it creates a cyclical reference to old data. So if you were looking at combat #10 in and then got into combat, you would always be returned to 10 after combat, even after looking at current again while out of combat.

For Example: Look at combat 10 out of combat, get into combat: It auto swaps the display (and possibly to current). When you get out of combat it will SwitchBack to combat 10, as expected. However, Out of Combat uses SwitchTo and saves the segment to `auto_switch_to_old`. When you get into your next combat, it calls SwitchBack which resets your combat to 10, and then calls SwitchTo which saves that combat 10 again. And then it sets segment to 0 if using show current. Repeat forever.

Setting the no_save flag on SwitchTo when leaving combat fixes this functionality.