### PR TITLE
Some logoff error checks

### DIFF
--- a/core/parser.lua
+++ b/core/parser.lua
@@ -5813,7 +5813,7 @@ local SPELL_POWER_PAIN = SPELL_POWER_PAIN or (PowerEnum and PowerEnum.Pain) or 1
 			_detalhes.can_panic_mode = true
 		end
 
-		if (_detalhes.CheckSwitchOnLogon and _detalhes.tabela_instancias[1] and _detalhes.tabela_instancias and getmetatable(_detalhes.tabela_instancias[1])) then
+		if (_detalhes.CheckSwitchOnLogon and _detalhes.tabela_instancias and _detalhes.tabela_instancias[1] and getmetatable(_detalhes.tabela_instancias[1])) then
 			tinsert(_detalhes_global.exit_log, "4 - Reversing switches.")
 			currentStep = "Check Switch on Logon"
 			xpcall(_detalhes.CheckSwitchOnLogon, saver_error)

--- a/functions/loaddata.lua
+++ b/functions/loaddata.lua
@@ -430,7 +430,11 @@ function _detalhes:LoadConfig()
 
 		--custom
 			_detalhes.custom = _detalhes_global.custom
+			if (_detalhes_global.custom.__index) then
+				C_Timer.After(5, function() print("|cFFFFAA00Details!|r error 0x8487, report on discord") end)
+			end
 			_detalhes.refresh:r_atributo_custom()
+			
 end
 
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/functions/loaddata.lua
+++ b/functions/loaddata.lua
@@ -430,7 +430,7 @@ function _detalhes:LoadConfig()
 
 		--custom
 			_detalhes.custom = _detalhes_global.custom
-			if (_detalhes_global.custom.__index) then
+			if (_detalhes_global.custom and _detalhes_global.custom[1] and details_global.custom[1].__index and _details_global.custom[1].__index._InstanceLastCombatShown) then
 				C_Timer.After(5, function() print("|cFFFFAA00Details!|r error 0x8487, report on discord") end)
 			end
 			_detalhes.refresh:r_atributo_custom()


### PR DESCRIPTION
Change the conditional for CheckSwitchOnLogon to not error if `tabela_instancias` doesn't exist. It will still error further down the line, but this is a slight issue.

Also add a message that will pop up if `custom.__index` exists in _detalhes_global on load, which shouldn't EVER be the case. Adding it so maybe can get an exitlog that shows why the index still exists.