### PR TITLE
Keystone realmNameGsub change

### DIFF
--- a/functions/slash.lua
+++ b/functions/slash.lua
@@ -2359,7 +2359,7 @@ if (WOW_PROJECT_ID == WOW_PROJECT_MAINLINE) then
 					local totalMembers, onlineMembers, onlineAndMobileMembers = GetNumGuildMembers()
 					local realmName = GetRealmName()
 					--create a string to use into the gsub call when removing the realm name from the player name, by default all player names returned from GetGuildRosterInfo() has PlayerName-RealmName format
-					local realmNameGsub = "%-" .. realmName
+					local realmNameGsub = "%-.*"
 					local guildName = GetGuildInfo("player")
 
 					if (guildName) then


### PR DESCRIPTION
If a user is on a realm with more than one word, `Area 52` for example, then GetRealmName returns it as `Area 52` however GetGuildRosterInfo will return it as `Area52`. There are also multi-realm guilds and /key will only cache guildmates on the same realm as you.

This change just removes the need to know the users realm when checking. Since `-` is a reserved character and cannot occur in a users name, it can be used to remove everything past the `-`. 