### PR TITLE
Ignore all Fodder to the Flame npcs again

### DIFF
--- a/core/parser.lua
+++ b/core/parser.lua
@@ -345,7 +345,14 @@
 
 	--list of ignored npcs by the user
 	_detalhes.default_ignored_npcs = {
-		--empty!
+		--DH Havoc Talent Fodder to the Flame
+		[169421] = true,
+		[169425] = true,
+		[168932] = true,
+		[169426] = true,
+		[169429] = true,
+		[169428] = true,
+		[169430] = true,
 	}
 
 	local ignored_npcids = {}


### PR DESCRIPTION
DH still has access to Fodder to the Flame, used to be the DH Necrolord ability. This just re-adds the npc ids that were removed for 10.0