### PR TITLE
Added options for Custom Text Offsets

### DIFF
--- a/classes/include_instance.lua
+++ b/classes/include_instance.lua
@@ -251,6 +251,10 @@ _detalhes.instance_defaults = {
 				textR_outline = false,
 				textR_outline_small = true,
 				textR_outline_small_color = {0, 0, 0, 1},
+        	-- left text offset
+				textL_offset = 0,
+		  	-- text y offset
+				text_yoffset = 0,
 			--bar height
 				height = 14,
 			--font size

--- a/frames/window_main.lua
+++ b/frames/window_main.lua
@@ -4165,7 +4165,7 @@ function gump:CreateNewLine(instance, index)
 	return newLine
 end
 
-function Details:SetBarTextSettings (size, font, fixedcolor, leftcolorbyclass, rightcolorbyclass, leftoutline, rightoutline, customrighttextenabled, customrighttext, percentage_type, showposition, customlefttextenabled, customlefttext, smalloutline_left, smalloutlinecolor_left, smalloutline_right, smalloutlinecolor_right, translittext)
+function Details:SetBarTextSettings (size, font, fixedcolor, leftcolorbyclass, rightcolorbyclass, leftoutline, rightoutline, customrighttextenabled, customrighttext, percentage_type, showposition, customlefttextenabled, customlefttext, smalloutline_left, smalloutlinecolor_left, smalloutline_right, smalloutlinecolor_right, translittext, yoffset, leftoffset)
 
 	--size
 	if (size) then
@@ -4255,6 +4255,13 @@ function Details:SetBarTextSettings (size, font, fixedcolor, leftcolorbyclass, r
 		self.row_info.textL_translit_text = translittext
 	end
 
+	if (yoffset) then
+		self.row_info.text_yoffset = yoffset
+	end
+
+	if (leftoffset) then
+		self.row_info.textL_offset = leftoffset
+	end
 	self:InstanceReset()
 	self:InstanceRefreshRows()
 end
@@ -4804,14 +4811,14 @@ function Details:InstanceRefreshRows(instance)
 
 			row.lineText4:SetText("")
 
-			row.lineText2:SetPoint("right", row.statusbar, "right", -self.fontstrings_text2_anchor, 0)
-			row.lineText3:SetPoint("right", row.statusbar, "right", -self.fontstrings_text3_anchor, 0)
-			row.lineText4:SetPoint("right", row.statusbar, "right", -self.fontstrings_text4_anchor, 0)
+			row.lineText2:SetPoint("right", row.statusbar, "right", -self.fontstrings_text2_anchor, self.row_info.text_yoffset)
+			row.lineText3:SetPoint("right", row.statusbar, "right", -self.fontstrings_text3_anchor, self.row_info.text_yoffset)
+			row.lineText4:SetPoint("right", row.statusbar, "right", -self.fontstrings_text4_anchor, self.row_info.text_yoffset)
 
 			if (no_icon) then
 				row.statusbar:SetPoint("topleft", row, "topleft")
 				row.statusbar:SetPoint("bottomright", row, "bottomright")
-				row.lineText1:SetPoint("left", row.statusbar, "left", 2, 0)
+				row.lineText1:SetPoint("left", row.statusbar, "left", self.row_info.textL_offset + 2, self.row_info.text_yoffset)
 				row.icone_classe:Hide()
 				row.iconHighlight:Hide()
 			else
@@ -4826,7 +4833,7 @@ function Details:InstanceRefreshRows(instance)
 				end
 
 				row.statusbar:SetPoint("bottomright", row, "bottomright")
-				row.lineText1:SetPoint("left", row.icone_classe, "right", 3, 0)
+				row.lineText1:SetPoint("left", row.icone_classe, "right", self.row_info.textL_offset + 3, self.row_info.text_yoffset)
 			end
 		else
 			row.lineText1:ClearAllPoints()
@@ -4839,14 +4846,14 @@ function Details:InstanceRefreshRows(instance)
 			row.lineText2:SetJustifyH("left")
 			row.lineText1:SetJustifyH("right")
 
-			row.lineText4:SetPoint("left", row.statusbar, "left", self.fontstrings_text4_anchor + 1, 0)
-			row.lineText3:SetPoint("left", row.statusbar, "left", self.fontstrings_text3_anchor + 1, 0)
-			row.lineText2:SetPoint("left", row.statusbar, "left", self.fontstrings_text2_anchor + 1, 0)
+			row.lineText4:SetPoint("left", row.statusbar, "left", self.fontstrings_text4_anchor + 1, self.row_info.text_yoffset)
+			row.lineText3:SetPoint("left", row.statusbar, "left", self.fontstrings_text3_anchor + 1, self.row_info.text_yoffset)
+			row.lineText2:SetPoint("left", row.statusbar, "left", self.fontstrings_text2_anchor + 1, self.row_info.text_yoffset)
 
 			if (no_icon) then
 				row.statusbar:SetPoint("topleft", row, "topleft")
 				row.statusbar:SetPoint("bottomright", row, "bottomright")
-				row.lineText1:SetPoint("right", row.statusbar, "right", -2, 0)
+				row.lineText1:SetPoint("right", row.statusbar, "right", self.row_info.textL_offset - 2, self.row_info.text_yoffset)
 				row.icone_classe:Hide()
 				row.iconHighlight:Hide()
 				--[[ Deprecation of right_to_left_texture in favor of StatusBar:SetReverseFill 5/2/2022 - Flamanis
@@ -4866,7 +4873,7 @@ function Details:InstanceRefreshRows(instance)
 
 				row.statusbar:SetPoint("topleft", row, "topleft")
 
-				row.lineText1:SetPoint("right", row.icone_classe, "left", -2, 0)
+				row.lineText1:SetPoint("right", row.icone_classe, "left", self.row_info.textL_offset - 2, self.row_info.text_yoffset)
 			end
 		end
 

--- a/frames/window_options2_sections.lua
+++ b/frames/window_options2_sections.lua
@@ -1917,6 +1917,19 @@ do
                 name = Loc ["STRING_OPTIONS_TEXT_SIZE"],
                 desc = Loc ["STRING_OPTIONS_TEXT_SIZE_DESC"],
             },
+            {--text yoffset  
+                type = "range",
+                get = function() return currentInstance.row_info.text_yoffset end,
+                set = function(self, fixedparam, value)
+                    editInstanceSetting(currentInstance, "SetBarTextSettings", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, value)
+                    afterUpdate()
+                end,
+                min = -10,
+                max = 10,
+                step = 1,
+                name = "Text Y Offset", -- Loc ["STRING_OPTIONS_TEXT_YOFFSET"]
+                desc = "Change the vertical offset for both left and right texts.", -- Loc ["STRING_OPTIONS_TEXT_YOFFSET_DESC"]
+            },
             {--text font 3
                 type = "select",
                 get = function() return currentInstance.row_info.font_face end,
@@ -2003,6 +2016,19 @@ do
                 end,
                 name = Loc ["STRING_OPTIONS_TEXT_LTRANSLIT"],
                 desc = Loc ["STRING_OPTIONS_TEXT_LTRANSLIT_DESC"],
+            },
+            {--text offset  
+                type = "range",
+                get = function() return currentInstance.row_info.textL_offset end,
+                set = function(self, fixedparam, value)
+                    editInstanceSetting(currentInstance, "SetBarTextSettings", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, value)
+                    afterUpdate()
+                end,
+                min = -10,
+                max = 50,
+                step = 1,
+                name = "Offset", -- Loc ["STRING_OPTIONS_TEXT_LOFFSET"]
+                desc = "Change the horizontal offset.", -- Loc ["STRING_OPTIONS_TEXT_LOFFSET_DESC"]
             },
 
             {type = "blank"}, --13


### PR DESCRIPTION
I added two options for bar text offsets:
 - The y offset shifts all text in a bar up/down and allows the user to move it according to their preference.
 - The textL_offset shifts only the left text of a bar, given that there are already options for the right texts.
 
The names and descriptions of these options don't have localisation yet.