### PR TITLE
Fix all issues related to new textL_offset and text_yoffset

### DIFF
--- a/classes/class_damage.lua
+++ b/classes/class_damage.lua
@@ -2474,6 +2474,7 @@ end
 		local maxStringLength_StringThree = 0
 		local profileOffsetString3 = self.fontstrings_text3_anchor
 		local profileOffsetString2 = self.fontstrings_text2_anchor
+		local profileYOffset = self.row_info.text_yoffset
 
 		Details.CacheInLineMaxDistance = Details.CacheInLineMaxDistance or {}
 		Details.CacheInLineMaxDistance[self:GetId()] = Details.CacheInLineMaxDistance[self:GetId()] or {[2] = profileOffsetString2, [3] = profileOffsetString3}
@@ -2514,7 +2515,7 @@ end
 			--update the lines
 			for lineId = 1, self:GetNumLinesShown() do
 				local thisLine = self:GetLine(lineId)
-				thisLine.lineText3:SetPoint("right", thisLine.statusbar, "right", -newOffset, 0)
+				thisLine.lineText3:SetPoint("right", thisLine.statusbar, "right", -newOffset, profileYOffset)
 			end
 		end
 
@@ -2535,7 +2536,7 @@ end
 				--update the lines
 				for lineId = 1, self:GetNumLinesShown() do
 					local thisLine = self:GetLine(lineId)
-					thisLine.lineText2:SetPoint("right", thisLine.statusbar, "right", -newOffset, 0)
+					thisLine.lineText2:SetPoint("right", thisLine.statusbar, "right", -newOffset, profileYOffset)
 				end
 			end
 		end

--- a/frames/window_main.lua
+++ b/frames/window_main.lua
@@ -2022,39 +2022,39 @@ end
 function Details:HandleTextsOnMouseClick(row, type)
 	if (self.bars_inverted) then
 		if (type == "down") then
-			row.lineText4:SetPoint("left", row.statusbar, "left", 2, -1)
+			row.lineText4:SetPoint("left", row.statusbar, "left", -self.fontstrings_text4_anchor + 2, self.row_info.text_yoffset - 1)
 
 			if (self.row_info.no_icon) then
-				row.lineText1:SetPoint("right", row.statusbar, "right", -1, -1)
+				row.lineText1:SetPoint("right", row.statusbar, "right", self.row_info.textL_offset - 1, self.row_info.text_yoffset - 1)
 			else
-				row.lineText1:SetPoint("right", row.icone_classe, "left", -1, -1)
+				row.lineText1:SetPoint("right", row.icone_classe, "left",self.row_info.textL_offset - 1, self.row_info.text_yoffset - 1)
 			end
 
 		elseif (type == "up") then
-			row.lineText4:SetPoint("left", row.statusbar, "left", 1, 0)
+			row.lineText4:SetPoint("left", row.statusbar, "left", -self.fontstrings_text4_anchor + 1, self.row_info.text_yoffset)
 
 			if (self.row_info.no_icon) then
-				row.lineText1:SetPoint("right", row.statusbar, "right", -2, 0)
+				row.lineText1:SetPoint("right", row.statusbar, "right", self.row_info.textL_offset - 2, self.row_info.text_yoffset)
 			else
-				row.lineText1:SetPoint("right", row.icone_classe, "left", -2, 0)
+				row.lineText1:SetPoint("right", row.icone_classe, "left", self.row_info.textL_offset - 2, self.row_info.text_yoffset)
 			end
 		end
 
 	else
 		if (type == "down") then
-			row.lineText4:SetPoint("right", row.statusbar, "right", 1, -1)
+			row.lineText4:SetPoint("right", row.statusbar, "right", -self.fontstrings_text4_anchor + 1, self.row_info.text_yoffset - 1)
 			if (self.row_info.no_icon) then
-				row.lineText1:SetPoint("left", row.statusbar, "left", 3, -1)
+				row.lineText1:SetPoint("left", row.statusbar, "left", self.row_info.textL_offset + 3, self.row_info.text_yoffset - 1)
 			else
-				row.lineText1:SetPoint("left", row.icone_classe, "right", 4, -1)
+				row.lineText1:SetPoint("left", row.icone_classe, "right", self.row_info.textL_offset + 4, self.row_info.text_yoffset - 1)
 			end
 
 		elseif (type == "up") then
-			row.lineText4:SetPoint("right", row.statusbar, "right")
+			row.lineText4:SetPoint("right", row.statusbar, "right", -self.fontstrings_text4_anchor, self.row_info.text_yoffset)
 			if (self.row_info.no_icon) then
-				row.lineText1:SetPoint("left", row.statusbar, "left", 2, 0)
+				row.lineText1:SetPoint("left", row.statusbar, "left", self.row_info.textL_offset + 2, self.row_info.text_yoffset)
 			else
-				row.lineText1:SetPoint("left", row.icone_classe, "right", 3, 0)
+				row.lineText1:SetPoint("left", row.icone_classe, "right", self.row_info.textL_offset + 3, self.row_info.text_yoffset)
 			end
 		end
 	end
@@ -4693,9 +4693,9 @@ end
 
 function Details:AdjustInLineTextPadding()
 	for _, row in ipairs(self.barras) do
-		row.lineText2:SetPoint("right", row.statusbar, "right", -self.fontstrings_text2_anchor, 0)
-		row.lineText3:SetPoint("right", row.statusbar, "right", -self.fontstrings_text3_anchor, 0)
-		row.lineText4:SetPoint("right", row.statusbar, "right", -self.fontstrings_text4_anchor, 0)
+		row.lineText2:SetPoint("right", row.statusbar, "right", -self.fontstrings_text2_anchor, self.row_info.text_yoffset)
+		row.lineText3:SetPoint("right", row.statusbar, "right", -self.fontstrings_text3_anchor, self.row_info.text_yoffset)
+		row.lineText4:SetPoint("right", row.statusbar, "right", -self.fontstrings_text4_anchor, self.row_info.text_yoffset)
 	end
 end
 

--- a/frames/window_options2_sections.lua
+++ b/frames/window_options2_sections.lua
@@ -2198,9 +2198,9 @@ do
         sectionOptions.always_boxfirst = true
         DF:BuildMenu(sectionFrame, sectionOptions, startX, startY-20, heightSize, false, options_text_template, options_dropdown_template, options_switch_template, true, options_slider_template, options_button_template)
 
-        local separatorOption = sectionFrame.widget_list[23]
-        local bracketOption = sectionFrame.widget_list[24]
-        local warningLabel = sectionFrame.widget_list[25]
+        local separatorOption = sectionFrame.widget_list[25]
+        local bracketOption = sectionFrame.widget_list[26]
+        local warningLabel = sectionFrame.widget_list[27]
         Details.options.textSeparatorOption = separatorOption
         Details.options.textbracketOption = bracketOption
 


### PR DESCRIPTION
With the new additions of Text Y Offset and the left text offset. The indexes to disable/hide were not updated properly and thus you could not edit Per Second, percent if multifontstring was enabled. And could not even see the seperator box.

A lot of SetPoint calls were not properly updated with the new anchor settings