### PR TITLE
Merge attonement with crit, and contrition with crit.

### DIFF
--- a/core/parser.lua
+++ b/core/parser.lua
@@ -322,6 +322,8 @@
 			[45284] = 188196, --shaman lightining bolt overloaded
 
 			[228361] = 228360, --shadow priest void erruption
+			[94472] = 81751, --disc priest attonement and crit. Crits use separate id.
+			[281469] = 270501, --disc priest contrition attonement and crit. Crits use separate id.
 		}
 	end
 


### PR DESCRIPTION
Discipline priests use Attonement for a lot of healing. When they shield a target, any damage they do heals those targets. If the damage crits, then the heal (Attonement) actually uses a second spell ID for the crit. Same for the Contrition heal. The regular heal and crit heal are separate ids. This just merges the two.