### PR TITLE
Add IconTexture directive to the TOCs

### DIFF
--- a/Details.toc
+++ b/Details.toc
@@ -5,6 +5,7 @@
 ## SavedVariablesPerCharacter: _detalhes_database
 ## OptionalDeps: Ace3, LibSharedMedia-3.0, LibWindow-1.1, LibDBIcon-1.0, NickTag-1.0, LibDataBroker-1.1, LibGraph-2.0
 ## Version: #@project-version@
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 ## X-Curse-Project-ID: 61284
 ## X-Wago-ID: 25NRDlK3

--- a/Details_Wrath.toc
+++ b/Details_Wrath.toc
@@ -5,6 +5,8 @@
 ## SavedVariablesPerCharacter: _detalhes_database
 ## OptionalDeps: Ace3, LibSharedMedia-3.0, LibWindow-1.1, LibDBIcon-1.0, NickTag-1.0, LibDataBroker-1.1, LibItemUpgradeInfo-1.0, LibGroupInSpecT-1.1, LibCompress, LibGraph-2.0
 ## Version: #@project-version@
+## IconTexture: Interface\AddOns\Details\images\minimap
+
 #@no-lib-strip@
 Libs\libs.xml
 #@end-no-lib-strip@

--- a/plugins/Details_Compare2/Details_Compare2.toc
+++ b/plugins/Details_Compare2/Details_Compare2.toc
@@ -2,5 +2,6 @@
 ## Title: Details!: Compare 2.0
 ## Notes: Replace the Compare tab in the player breakdown window.
 ## RequiredDeps: Details
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 Details_Compare2.lua

--- a/plugins/Details_DataStorage/Details_DataStorage.toc
+++ b/plugins/Details_DataStorage/Details_DataStorage.toc
@@ -5,5 +5,6 @@
 ## LoadOnDemand: 1
 ## Dependencies: Details
 ## SavedVariables: DetailsDataStorage
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 Details_DataStorage.lua

--- a/plugins/Details_EncounterDetails/Details_EncounterDetails-Wrath.toc
+++ b/plugins/Details_EncounterDetails/Details_EncounterDetails-Wrath.toc
@@ -4,6 +4,7 @@
 ## RequiredDeps: Details
 ## OptionalDeps: Ace3
 ## SavedVariablesPerCharacter: EncounterDetailsDB
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 enUS.lua
 ptBR.lua

--- a/plugins/Details_EncounterDetails/Details_EncounterDetails.toc
+++ b/plugins/Details_EncounterDetails/Details_EncounterDetails.toc
@@ -4,6 +4,7 @@
 ## RequiredDeps: Details
 ## OptionalDeps: Ace3
 ## SavedVariablesPerCharacter: EncounterDetailsDB
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 ## X-Wago-ID: 7nGvv0Gx
 

--- a/plugins/Details_EncounterDetails/Details_EncounterDetails_Wrath.toc
+++ b/plugins/Details_EncounterDetails/Details_EncounterDetails_Wrath.toc
@@ -4,6 +4,7 @@
 ## RequiredDeps: Details
 ## OptionalDeps: Ace3
 ## SavedVariablesPerCharacter: EncounterDetailsDB
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 enUS.lua
 ptBR.lua

--- a/plugins/Details_RaidCheck/Details_RaidCheck-Wrath.toc
+++ b/plugins/Details_RaidCheck/Details_RaidCheck-Wrath.toc
@@ -2,6 +2,7 @@
 ## Title: Details!: Raid Check (plugin)
 ## Notes: Show talents and item level for all members in your group, also shows food and flask state.
 ## RequiredDeps: Details
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 #@no-lib-strip@
 embeds.xml

--- a/plugins/Details_RaidCheck/Details_RaidCheck.toc
+++ b/plugins/Details_RaidCheck/Details_RaidCheck.toc
@@ -2,6 +2,7 @@
 ## Title: Details!: Raid Check (plugin)
 ## Notes: Show talents and item level for all members in your group, also shows food and flask state.
 ## RequiredDeps: Details
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 ## X-Wago-ID: WL6Jk2Kv
 

--- a/plugins/Details_RaidCheck/Details_RaidCheck_Wrath.toc
+++ b/plugins/Details_RaidCheck/Details_RaidCheck_Wrath.toc
@@ -2,6 +2,7 @@
 ## Title: Details!: Raid Check (plugin)
 ## Notes: Show talents and item level for all members in your group, also shows food and flask state.
 ## RequiredDeps: Details
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 #@no-lib-strip@
 embeds.xml

--- a/plugins/Details_Streamer/Details_Streamer-Wrath.toc
+++ b/plugins/Details_Streamer/Details_Streamer-Wrath.toc
@@ -3,6 +3,7 @@
 ## Notes: Show which spells you are casting, viewers can see what are you doing and follow your steps.
 ## RequiredDeps: Details
 ## SavedVariables: Details_StreamerDB
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 #@no-lib-strip@
 embeds.xml

--- a/plugins/Details_Streamer/Details_Streamer.toc
+++ b/plugins/Details_Streamer/Details_Streamer.toc
@@ -3,6 +3,7 @@
 ## Notes: Show which spells you are casting, viewers can see what are you doing and follow your steps.
 ## RequiredDeps: Details
 ## SavedVariables: Details_StreamerDB
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 ## X-Wago-ID: VBNB9MGx
 

--- a/plugins/Details_Streamer/Details_Streamer_Wrath.toc
+++ b/plugins/Details_Streamer/Details_Streamer_Wrath.toc
@@ -3,6 +3,7 @@
 ## Notes: Show which spells you are casting, viewers can see what are you doing and follow your steps.
 ## RequiredDeps: Details
 ## SavedVariables: Details_StreamerDB
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 #@no-lib-strip@
 embeds.xml

--- a/plugins/Details_TinyThreat/Details_TinyThreat-Classic.toc
+++ b/plugins/Details_TinyThreat/Details_TinyThreat-Classic.toc
@@ -3,6 +3,7 @@
 ## Notes: Threat meter plugin, show threat for group members in the window. Select it from the Plugin menu in the Orange Cogwheel.
 ## RequiredDeps: Details
 ## OptionalDeps: Ace3
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 #@no-lib-strip@
 embeds.xml

--- a/plugins/Details_TinyThreat/Details_TinyThreat-Wrath.toc
+++ b/plugins/Details_TinyThreat/Details_TinyThreat-Wrath.toc
@@ -3,6 +3,7 @@
 ## Notes: Threat meter plugin, show threat for group members in the window. Select it from the Plugin menu in the Orange Cogwheel.
 ## RequiredDeps: Details
 ## OptionalDeps: Ace3
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 #@no-lib-strip@
 embeds.xml

--- a/plugins/Details_TinyThreat/Details_TinyThreat.toc
+++ b/plugins/Details_TinyThreat/Details_TinyThreat.toc
@@ -3,6 +3,7 @@
 ## Notes: Threat meter plugin, show threat for group members in the window. Select it from the Plugin menu in the Orange Cogwheel.
 ## RequiredDeps: Details
 ## OptionalDeps: Ace3
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 ## X-Wago-ID: Rn6VJW6d
 

--- a/plugins/Details_TinyThreat/Details_TinyThreat_Wrath.toc
+++ b/plugins/Details_TinyThreat/Details_TinyThreat_Wrath.toc
@@ -3,6 +3,7 @@
 ## Notes: Threat meter plugin, show threat for group members in the window. Select it from the Plugin menu in the Orange Cogwheel.
 ## RequiredDeps: Details
 ## OptionalDeps: Ace3
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 #@no-lib-strip@
 embeds.xml

--- a/plugins/Details_Vanguard/Details_Vanguard-Wrath.toc
+++ b/plugins/Details_Vanguard/Details_Vanguard-Wrath.toc
@@ -4,6 +4,7 @@
 ## SavedVariablesPerCharacter: _detalhes_databaseVanguard
 ## RequiredDeps: Details
 ## OptionalDeps: Ace3
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 #@no-lib-strip@
 embeds.xml

--- a/plugins/Details_Vanguard/Details_Vanguard.toc
+++ b/plugins/Details_Vanguard/Details_Vanguard.toc
@@ -4,6 +4,7 @@
 ## SavedVariablesPerCharacter: _detalhes_databaseVanguard
 ## RequiredDeps: Details
 ## OptionalDeps: Ace3
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 ## X-Wago-ID: ZQ6abgKW
 

--- a/plugins/Details_Vanguard/Details_Vanguard_Wrath.toc
+++ b/plugins/Details_Vanguard/Details_Vanguard_Wrath.toc
@@ -4,6 +4,7 @@
 ## SavedVariablesPerCharacter: _detalhes_databaseVanguard
 ## RequiredDeps: Details
 ## OptionalDeps: Ace3
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 #@no-lib-strip@
 embeds.xml


### PR DESCRIPTION
Uses the Minimap icon. If a plugin is installed without the base Details it will show a blank icon.