### PR TITLE
Set up statusbar options instead of using metatable

### DIFF
--- a/core/plugins_statusbar.lua
+++ b/core/plugins_statusbar.lua
@@ -483,7 +483,9 @@
 
 		--options table
 		childTable.options = instance.StatusBar.options[mainObject.real_name]
-		if (not childTable.options) then
+		if (instance.StatusBar.options[mainObject.real_name]) then
+			childTable.options = instance.StatusBar.options[mainObject.real_name]
+		else
 			childTable.options = {
 			textStyle = 2,
 			textColor = {unpack(DEFAULT_CHILD_FONTCOLOR)},


### PR DESCRIPTION
Stops the statusbar from using the Details.options table from its metatable.