### PR TITLE
Options fix and Cyclical pet ownership fix

### DIFF
--- a/classes/container_actors.lua
+++ b/classes/container_actors.lua
@@ -722,7 +722,7 @@ end
 
 		if (container_pets[actorSerial]) then --this is a registered pet
 			local petName, ownerName, ownerGUID, ownerFlag = Details.tabela_pets:PegaDono(actorSerial, actorName, actorFlags)
-			if (petName and ownerName) then
+			if (petName and ownerName and ownerGUID ~= actorSerial) then
 				actorName = petName
 				petOwnerObject = self:PegarCombatente(ownerGUID, ownerName, ownerFlag, true)
 			end

--- a/frames/window_options2.lua
+++ b/frames/window_options2.lua
@@ -326,6 +326,9 @@ function Details222.OptionsPanel.InitializeOptionsWindow(instance)
         end
 
         optionsFrame.sectionFramesContainer[sectionId]:Show()
+        if(optionsFrame.sectionFramesContainer[sectionId].RefreshOptions) then
+            optionsFrame.sectionFramesContainer[sectionId]:RefreshOptions()
+        end
         --hightlight the option button
         optionsFrame.sectionFramesContainer[sectionId].sectionButton:SetTemplate(options_button_template_selected)
         optionsFrame.sectionFramesContainer[sectionId].sectionButton:SetIcon({1, 1, 0}, 4, section_menu_button_height -4, "overlay")

--- a/frames/window_options2_sections.lua
+++ b/frames/window_options2_sections.lua
@@ -2453,7 +2453,7 @@ do
 
             {--title bar icons position X
                 type = "range",
-                get = function() return currentInstance.menu_anchor[1] end,
+                get = function() return currentInstance.toolbar_side == 1 and currentInstance.menu_anchor[1] or currentInstance.menu_anchor_down[1] end,
                 set = function(self, fixedparam, value)
                     editInstanceSetting(currentInstance, "MenuAnchor", value)
                     afterUpdate()
@@ -2467,7 +2467,7 @@ do
 
             {--title bar icons position Y
                 type = "range",
-                get = function() return currentInstance.menu_anchor[2] end,
+                get = function() return currentInstance.toolbar_side == 1 and currentInstance.menu_anchor[2] or currentInstance.menu_anchor_down[2] end,
                 set = function(self, fixedparam, value)
                     editInstanceSetting(currentInstance, "MenuAnchor", nil, value)
                     afterUpdate()


### PR DESCRIPTION
Force all options to reload when their tab is selected (Just fixes any issues in future of settings being changed, required for below not to be weird.)
X and Y position of title bar buttons swap their position table to the correct one when the Title Bar is attached to bottom

Changed PegarCombatente to potentially fix a stack overflow. If `PegaDono` returns self GUID then ignore it. 