### PR TITLE
Add Github releases to release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
 name: Release AddOn
 
-#on: [push]
 on:
   push:
     branches:
@@ -8,28 +7,20 @@ on:
     tags:
       - '**'
 
-env:
-  CF_API_KEY: ${{ secrets.CF_API_KEY }}
-  WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
-
 jobs:
-#  full_package_release:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v3
-#        with:
-#          fetch-depth: 0
-
-#      - uses: BigWigsMods/packager@v2
-
   standalone_release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout Repository
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - uses: BigWigsMods/packager@v2
+      - name: Create Package
+        uses: BigWigsMods/packager@v2
         with:
-          pkgmeta: package_sa.pkgmeta
-          args: -a qv63A7Gb
+          args: -m package_sa.pkgmeta -a qv63A7Gb
+        env:
+          CF_API_KEY: ${{ secrets.CF_API_KEY }}
+          WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
+          GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #172 

Adds Github releases to the "Release AddOn" action and performs other mild cleanups of the workflow's `.yml`.

1. Correctly specifies `pkgmeta` to packager (now runs without warnings)
2. Adds the Github OAuth token to the environment
3. Restructures the workflow spec so that *only* the packager has access to the relevant secrets
4. Adds human readable names

Was tested in another fork by tagging 2 subsequent commits (the first fails to release due to a MASSIVE changelog, the second succeeds) and then installing the addon via CurseBreaker. `install gh:nonolai/Details`. Due to not having secrets access, WAGO uploading was disabled on the test.

Happy to do further testing, but it's hard to do well without running on the real repository.

Requires the GH OAuth token to have "Read and write permissions" (Repo > Settings > Actions > General > Workflow permissions)
