### PR TITLE
Unlock Details Streamer for use on Era

### DIFF
--- a/plugins/Details_Streamer/Details_Streamer.lua
+++ b/plugins/Details_Streamer/Details_Streamer.lua
@@ -2349,9 +2349,9 @@ end
 
 
 function StreamOverlay:OnEvent (_, event, ...)
-	if (DetailsFramework and DetailsFramework.IsClassicWow()) then
-		return
-	end
+	--if (DetailsFramework and DetailsFramework.IsClassicWow()) then
+	--	return
+	--end
 	if (event == "ADDON_LOADED") then
 		local AddonName = select (1, ...)
 		if (AddonName == "Details_Streamer") then


### PR DESCRIPTION
With the backend changes on Era, after testing, Details Streamer now works out the box.