### PR TITLE
corrected spelling of the word 'height' in 'Details-enUS.lua'

### DIFF
--- a/locales/Details-enUS.lua
+++ b/locales/Details-enUS.lua
@@ -1495,7 +1495,7 @@ L["STRING_RESIZE_COMMON"] = [=[Resize
 ]=]
 L["STRING_RESIZE_HORIZONTAL"] = [=[Resize the width of all
  windows in the group]=]
-L["STRING_RESIZE_VERTICAL"] = [=[Resize the heigth of all
+L["STRING_RESIZE_VERTICAL"] = [=[Resize the height of all
  windows in the group]=]
 L["STRING_RIGHT"] = "right"
 L["STRING_RIGHT_TO_LEFT"] = "Right to Left"


### PR DESCRIPTION
This spelling error was present in the small tooltip that pops up when you hover the bottom right corner of the data window (the area where you can click and drag to resize the window).