### PR TITLE
Fix a lot of Name-Realm issues

### DIFF
--- a/Libs/NickTag-1.0/NickTag-1.0.lua
+++ b/Libs/NickTag-1.0/NickTag-1.0.lua
@@ -585,7 +585,11 @@ end
 		--here we format the text to match titles, e.g converts name like "JASON NICKSHOW" into "Jason Nickshow". 
 		name = name:gsub ("(%a)([%w_']*)", titlecase)
 		
-		local playerName = UnitName ("player")
+		local playerName, realmName = UnitFullName ("player")
+
+		if(select(4, GetBuildInfo()) >= 100200) then
+			playerName = playerName .. '-' .. realmName
+		end
 		
 		--get the full nick table.
 		local nickTable = NickTag:GetNicknameTable (playerName)

--- a/classes/container_actors.lua
+++ b/classes/container_actors.lua
@@ -784,7 +784,7 @@ end
 
 		--check ownership
 		if (petOwnerObject and Details.immersion_pets_on_solo_play) then
-			if (UnitIsUnit("player", petOwnerObject.nome)) then
+			if (Details.playername == petOwnerObject.nome) then
 				if (not Details.in_group) then
 					newActor.grupo = true
 				end

--- a/core/gears.lua
+++ b/core/gears.lua
@@ -1678,7 +1678,7 @@ function Details.Database.StoreEncounter(combat)
 			bossData.time_incombat = bossData.time_incombat + encounterElapsedTime
 
 			--player best dps
-			local player = combat(DETAILS_ATTRIBUTE_DAMAGE, UnitName("player"))
+			local player = combat(DETAILS_ATTRIBUTE_DAMAGE, Details.playername)
 			if (player) then
 				local playerDps = player.total / encounterElapsedTime
 				if (playerDps > bossData.dps_best) then

--- a/core/parser.lua
+++ b/core/parser.lua
@@ -2813,7 +2813,7 @@
 				end
 			end
 
-			if (override_aura_spellid[spellId] and UnitIsUnit(sourceName, "player")) then
+			if (override_aura_spellid[spellId] and sourceName == Details.playername) then
 				local auraName, texture, count, auraType, duration, expirationTime, sourceUnit, isStealable, nameplateShowPersonal, spellId, canApplyAura, isBossAura, isFromPlayerOrPlayerPet, nameplateShowAll, timeMod, v1, v2, v3, v4, v5 = Details:FindBuffCastedByUnitName(sourceName, spellId, sourceName)
 				if (auraName) then
 					local overrideTable = override_aura_spellid[spellId]
@@ -6822,7 +6822,7 @@ local SPELL_POWER_PAIN = SPELL_POWER_PAIN or (PowerEnum and PowerEnum.Pain) or 1
 			end
 
 			--player
-			local playerName = GetUnitName("player", true)
+			local playerName = Details.playername
 			local playerGUID = UnitGUID("player")
 
 			raid_members_cache[playerGUID] = playerName
@@ -6837,7 +6837,7 @@ local SPELL_POWER_PAIN = SPELL_POWER_PAIN or (PowerEnum and PowerEnum.Pain) or 1
 				auto_regen_cache[playerName] = auto_regen_power_specs[Details.cached_specs[playerGUID]]
 			end
 		else
-			local playerName = GetUnitName("player", true)
+			local playerName = Details.playername
 			local playerGUID = UnitGUID("player")
 
 			raid_members_cache[playerGUID] = playerName
@@ -7089,7 +7089,7 @@ local SPELL_POWER_PAIN = SPELL_POWER_PAIN or (PowerEnum and PowerEnum.Pain) or 1
 					return unitId
 				end
 			end
-			if (UnitName("player") == unitName) then
+			if (Details.playername == unitName) then
 				return "player"
 			end
 		end

--- a/core/util.lua
+++ b/core/util.lua
@@ -1349,7 +1349,7 @@ end
 				end
 			end
 		end
-		if (UnitName ("player") == name) then
+		if (UnitName ("player") == name or Details.playername == name) then
 			return UnitGUID("player")
 		end
 		return nil

--- a/frames/window_options2_sections.lua
+++ b/frames/window_options2_sections.lua
@@ -607,7 +607,7 @@ do
             {type = "label", get = function() return Loc ["STRING_OPTIONS_SOCIAL"] end, text_template = subSectionTitleTextTemplate},
             {--nickname
                 type = "textentry",
-                get = function() return Details:GetNickname(_G.UnitName("player"), _G.UnitName("player"), true) or "" end,
+                get = function() return Details:GetNickname(Details.playername, _G.UnitName("player"), true) or "" end,
                 func = function(self, _, text)
                     local accepted, errortext = Details:SetNickname(text)
                     if (not accepted) then

--- a/functions/deathrecap.lua
+++ b/functions/deathrecap.lua
@@ -601,7 +601,7 @@ hooksecurefunc (_G, "DeathRecap_LoadUI", function()
 	hooksecurefunc (_G, "DeathRecapFrame_OpenRecap", function(RecapID)
         local currentCombat = Details:GetCurrentCombat()
         --get the player current death and link the death table with the death recapID
-        local playerDeaths = currentCombat:GetPlayerDeaths(UnitName("player"))
+        local playerDeaths = currentCombat:GetPlayerDeaths(Details.playername)
         if (playerDeaths) then
             local latestDeath = playerDeaths[#playerDeaths]
             if (latestDeath) then

--- a/functions/dungeon.lua
+++ b/functions/dungeon.lua
@@ -151,13 +151,13 @@ local tickerCallback = function(tickerObject)
 	--tick damage
 	local totalPlayers = GetNumGroupMembers()
 	for i = 1, totalPlayers-1 do
-		local unitName, unitRealm = UnitName ("party" .. i)
+		local unitName, unitRealm = UnitFullName ("party" .. i)
 		if (unitName) then
 			addPlayerDamage(unitName, unitRealm)
 		end
 	end
 
-	addPlayerDamage(UnitName("player"))
+	addPlayerDamage(UnitFullName("player"))
 end
 
 function mythicDungeonCharts:OnBossDefeated()

--- a/functions/pack.lua
+++ b/functions/pack.lua
@@ -427,7 +427,7 @@ function Details.packFunctions.PackDamage(combatObject)
     local actorsToPack = {}
 
     --get the player object from the combat > damage container
-    local playerName = UnitName("player")
+    local playerName = Details.playername
     local playerObject = combatObject:GetActor(DETAILS_ATTRIBUTE_DAMAGE, playerName)
     if (not playerObject) then
         if (isDebugging) then
@@ -677,7 +677,7 @@ function Details.packFunctions.PackHeal(combatObject)
     local actorsToPack = {}
 
     --get the player object from the combat > damage container
-    local playerName = UnitName("player")
+    local playerName = Details.playername
     local playerObject = combatObject:GetActor(DETAILS_ATTRIBUTE_HEAL, playerName)
     if (not playerObject) then
         if (isDebugging) then

--- a/functions/spec_augmentation.lua
+++ b/functions/spec_augmentation.lua
@@ -21,7 +21,7 @@ function augmentationFunctions.BuffIn(token, time, sourceSerial, sourceName, sou
         end
 
     elseif (spellId == 413984) then --ss
-        if (UnitExists(targetName) and not UnitIsUnit("player", targetName)) then
+        if (UnitExists(targetName) and targetName ~= Details.playername) then
             local auraName, texture, count, auraType, duration, expirationTime, sourceUnit, isStealable, nameplateShowPersonal, spellId, canApplyAura, isBossAura, isFromPlayerOrPlayerPet, nameplateShowAll, timeMod, v1, v2, v3, v4, v5 = Details:FindBuffCastedByUnitName(targetName, spellId, sourceName)
             local versaGained = v1
             if (type(versaGained) == "number") then
@@ -92,7 +92,7 @@ function augmentationFunctions.BuffRefresh(token, time, sourceSerial, sourceName
         end
 
     elseif (spellId == 413984) then --ss
-        if (UnitExists(targetName) and not UnitIsUnit("player", targetName)) then
+        if (UnitExists(targetName) and targetName ~= Details.playername) then
             local auraName, texture, count, auraType, duration, expirationTime, sourceUnit, isStealable, nameplateShowPersonal, spellId, canApplyAura, isBossAura, isFromPlayerOrPlayerPet, nameplateShowAll, timeMod, v1, v2, v3, v4, v5 = Details:FindBuffCastedByUnitName (targetName, spellId, sourceName)
             local versaGained = v1
 

--- a/functions/timedata.lua
+++ b/functions/timedata.lua
@@ -590,7 +590,7 @@ function Details222.TimeCapture.StartCombatTimer(combatObject)
 	Details222.TimeCapture.CombatTimeTicker = C_Timer.NewTicker(1, combatTimeTicker)
 
 	--debug: starting only for the player
-	Details222.TimeCapture.Start(UnitName("player"), DETAILS_ATTRIBUTE_DAMAGE)
+	Details222.TimeCapture.Start(Details.playername, DETAILS_ATTRIBUTE_DAMAGE)
 end
 
 --combat ended on Details! end

--- a/plugins/Details_Streamer/Details_Streamer.lua
+++ b/plugins/Details_Streamer/Details_Streamer.lua
@@ -2356,7 +2356,11 @@ function StreamOverlay:OnEvent (_, event, ...)
 		local AddonName = select (1, ...)
 		if (AddonName == "Details_Streamer") then
 			
-			playerName = UnitName ("player")
+			local interimPlayerName, playerRealm = UnitFullName ("player")
+
+			if(select(4, GetBuildInfo()) >= 100200) then
+				playerName = interimPlayerName .. '-' .. playerRealm
+			end
 
 			if (_G.Details) then
 			


### PR DESCRIPTION
Fixes Nicktag to save the player's chosen name using `Name-Realm` if on 10.2+

Changes a lot of UnitIsUnit('player', X) calls to instead compare against `Details.playername`

Likewise with UnitName, changed them to use Details.playername instead of getting the name from Blizz.