### PR TITLE
Use original cleu handler for Era.

### DIFF
--- a/core/parser.lua
+++ b/core/parser.lua
@@ -6530,7 +6530,7 @@ local SPELL_POWER_PAIN = SPELL_POWER_PAIN or (PowerEnum and PowerEnum.Pain) or 1
 		end
 	end
 
-	if(isERA) then
+	if(false and isERA) then
 		eraNamedSpellsToID = {
 		["SPELL_PERIODIC_DAMAGE"] = true,
 		["SPELL_DAMAGE"] = true,


### PR DESCRIPTION
Disables the cleu changes on classic_era. Era now gives spellId in cleu events instead of just 0.