### PR TITLE
Allow external code to add values to the Bars:General->Icons->Texture dropdown

### DIFF
--- a/core/util.lua
+++ b/core/util.lua
@@ -1807,17 +1807,18 @@ end
 
     local defaultIconSize = {16, 16}
     local defaultIconTexture = [[Interface\WorldStateFrame\ICONS-CLASSES]]
-    local defaultIconCoords = {0.25, 0.50, 0, 0.25}
+    local defaultClassIconCoords = {0.25, 0.50, 0, 0.25}
+    local defaultSpecIconCoords = {2/512, 32/512, 480/512, 510/512}
 
     Details222.iconSetList = {
-        {value = [[]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE1"], icon = defaultIconTexture, texcoord = defaultIconCoords, iconsize = defaultIconSize, iconcolor = {1, 1, 1, .3}},
-        {value = [[Interface\AddOns\Details\images\classes_small]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE2"], icon = defaultIconTexture, texcoord = defaultIconCoords, iconsize = defaultIconSize},
-        {value = [[Interface\AddOns\Details\images\spec_icons_normal]], label = "Specialization", icon = [[Interface\AddOns\Details\images\icons]], texcoord = {2/512, 32/512, 480/512, 510/512}, iconsize = defaultIconSize},
-        {value = [[Interface\AddOns\Details\images\spec_icons_normal_alpha]], label = "Specialization Alpha", icon = [[Interface\AddOns\Details\images\icons]], texcoord = {2/512, 32/512, 480/512, 510/512}, iconsize = defaultIconSize},
-        {value = [[Interface\AddOns\Details\images\classes_small_bw]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE3"], icon = defaultIconTexture, texcoord = defaultIconCoords, iconsize = defaultIconSize},
-        {value = [[Interface\AddOns\Details\images\classes_small_alpha]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE4"], icon = defaultIconTexture, texcoord = defaultIconCoords, iconsize = defaultIconSize},
-        {value = [[Interface\AddOns\Details\images\classes_small_alpha_bw]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE6"], icon = defaultIconTexture, texcoord = defaultIconCoords, iconsize = defaultIconSize},
-        {value = [[Interface\AddOns\Details\images\classes]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE5"], icon = defaultIconTexture, texcoord = defaultIconCoords, iconsize = defaultIconSize},
+        {value = [[]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE1"], icon = defaultIconTexture, texcoord = defaultClassIconCoords, iconsize = defaultIconSize, iconcolor = {1, 1, 1, .3}},
+        {value = [[Interface\AddOns\Details\images\classes_small]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE2"], icon = defaultIconTexture, texcoord = defaultClassIconCoords, iconsize = defaultIconSize},
+        {value = [[Interface\AddOns\Details\images\spec_icons_normal]], label = "Specialization", isSpec = true, icon = [[Interface\AddOns\Details\images\icons]], texcoord = defaultSpecIconCoords, iconsize = defaultIconSize},
+        {value = [[Interface\AddOns\Details\images\spec_icons_normal_alpha]], label = "Specialization Alpha", isSpec = true, icon = [[Interface\AddOns\Details\images\icons]], texcoord = defaultSpecIconCoords, iconsize = defaultIconSize},
+        {value = [[Interface\AddOns\Details\images\classes_small_bw]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE3"], icon = defaultIconTexture, texcoord = defaultClassIconCoords, iconsize = defaultIconSize},
+        {value = [[Interface\AddOns\Details\images\classes_small_alpha]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE4"], icon = defaultIconTexture, texcoord = defaultClassIconCoords, iconsize = defaultIconSize},
+        {value = [[Interface\AddOns\Details\images\classes_small_alpha_bw]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE6"], icon = defaultIconTexture, texcoord = defaultClassIconCoords, iconsize = defaultIconSize},
+        {value = [[Interface\AddOns\Details\images\classes]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE5"], icon = defaultIconTexture, texcoord = defaultClassIconCoords, iconsize = defaultIconSize},
     }
 
     function Details:AddCustomIconSet (path, label, isSpecIcons, icon, texCoords, iconSize, iconColor)
@@ -1827,7 +1828,7 @@ end
                 label = label or 'Missing Label',
                 isSpec = isSpecIcons,
                 icon = icon or defaultIconTexture,
-                texcoord = texCoords or defaultIconCoords,
+                texcoord = texCoords or (isSpecIcons and defaultSpecIconCoords or defaultClassIconCoords),
                 iconsize = iconSize or defaultIconSize,
                 iconcolor = iconColor
             }

--- a/core/util.lua
+++ b/core/util.lua
@@ -1804,3 +1804,32 @@ end
 			barra.lineText4:SetSize(texto_direita_tamanho+5, 15)
 		end
 	end
+
+    local defaultIconSize = {16, 16}
+    local defaultIconTexture = [[Interface\WorldStateFrame\ICONS-CLASSES]]
+    local defaultIconCoords = {0.25, 0.50, 0, 0.25}
+
+    Details222.iconSetList = {
+        {value = [[]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE1"], icon = defaultIconTexture, texcoord = defaultIconCoords, iconsize = defaultIconSize, iconcolor = {1, 1, 1, .3}},
+        {value = [[Interface\AddOns\Details\images\classes_small]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE2"], icon = defaultIconTexture, texcoord = defaultIconCoords, iconsize = defaultIconSize},
+        {value = [[Interface\AddOns\Details\images\spec_icons_normal]], label = "Specialization", icon = [[Interface\AddOns\Details\images\icons]], texcoord = {2/512, 32/512, 480/512, 510/512}, iconsize = defaultIconSize},
+        {value = [[Interface\AddOns\Details\images\spec_icons_normal_alpha]], label = "Specialization Alpha", icon = [[Interface\AddOns\Details\images\icons]], texcoord = {2/512, 32/512, 480/512, 510/512}, iconsize = defaultIconSize},
+        {value = [[Interface\AddOns\Details\images\classes_small_bw]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE3"], icon = defaultIconTexture, texcoord = defaultIconCoords, iconsize = defaultIconSize},
+        {value = [[Interface\AddOns\Details\images\classes_small_alpha]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE4"], icon = defaultIconTexture, texcoord = defaultIconCoords, iconsize = defaultIconSize},
+        {value = [[Interface\AddOns\Details\images\classes_small_alpha_bw]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE6"], icon = defaultIconTexture, texcoord = defaultIconCoords, iconsize = defaultIconSize},
+        {value = [[Interface\AddOns\Details\images\classes]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE5"], icon = defaultIconTexture, texcoord = defaultIconCoords, iconsize = defaultIconSize},
+    }
+
+    function Details:AddCustomIconSet (path, label, isSpecIcons, icon, texCoords, iconSize, iconColor)
+        table.insert(Details222.iconSetList,
+            {
+                value = path or [[]],
+                label = label or 'Missing Label',
+                isSpec = isSpecIcons,
+                icon = icon or defaultIconTexture,
+                texcoord = texCoords or defaultIconCoords,
+                iconsize = iconSize or defaultIconSize,
+                iconcolor = iconColor
+            }
+        )
+    end

--- a/frames/window_main.lua
+++ b/frames/window_main.lua
@@ -4422,6 +4422,7 @@ function Details:SetBarSpecIconSettings(enabled, iconfile, fulltrack)
 			Details.track_specs = true
 			Details:TrackSpecsNow (fulltrack)
 		end
+        self.row_info.no_icon = false
 	else
 		local have_enabled
 		for _, instance in ipairs(Details.tabela_instancias) do

--- a/frames/window_options2_sections.lua
+++ b/frames/window_options2_sections.lua
@@ -1165,21 +1165,15 @@ do
         return texTable2
     end
 
-    local iconsize = {16, 16}
-    local icontexture = [[Interface\WorldStateFrame\ICONS-CLASSES]]
-    local iconcoords = {0.25, 0.50, 0, 0.25}
-    local list = {
-        {value = [[]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE1"], onclick = OnSelectIconFile, icon = icontexture, texcoord = iconcoords, iconsize = iconsize, iconcolor = {1, 1, 1, .3}},
-        {value = [[Interface\AddOns\Details\images\classes_small]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE2"], onclick = OnSelectIconFile, icon = icontexture, texcoord = iconcoords, iconsize = iconsize},
-        {value = [[Interface\AddOns\Details\images\spec_icons_normal]], label = "Specialization", onclick = OnSelectIconFileSpec, icon = [[Interface\AddOns\Details\images\icons]], texcoord = {2/512, 32/512, 480/512, 510/512}, iconsize = iconsize},
-        {value = [[Interface\AddOns\Details\images\spec_icons_normal_alpha]], label = "Specialization Alpha", onclick = OnSelectIconFileSpec, icon = [[Interface\AddOns\Details\images\icons]], texcoord = {2/512, 32/512, 480/512, 510/512}, iconsize = iconsize},
-        {value = [[Interface\AddOns\Details\images\classes_small_bw]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE3"], onclick = OnSelectIconFile, icon = icontexture, texcoord = iconcoords, iconsize = iconsize},
-        {value = [[Interface\AddOns\Details\images\classes_small_alpha]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE4"], onclick = OnSelectIconFile, icon = icontexture, texcoord = iconcoords, iconsize = iconsize},
-        {value = [[Interface\AddOns\Details\images\classes_small_alpha_bw]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE6"], onclick = OnSelectIconFile, icon = icontexture, texcoord = iconcoords, iconsize = iconsize},
-        {value = [[Interface\AddOns\Details\images\classes]], label = Loc ["STRING_OPTIONS_BAR_ICONFILE5"], onclick = OnSelectIconFile, icon = icontexture, texcoord = iconcoords, iconsize = iconsize},
-    }
     local builtIconList = function()
-        return list
+        for k,v in ipairs(Details222.iconSetList) do
+            if v.isSpec then
+                v.onclick = OnSelectIconFileSpec
+            else
+                v.onclick = OnSelectIconFile
+            end
+        end
+        return Details222.iconSetList
     end
 
     local buildSection = function(sectionFrame)


### PR DESCRIPTION
Moves the icon set list into the Details222 namespace instead of a local variable in options, and adds new function in `util.lua` called Details:AddCustomIconSet which allows other addons and plugins to be able to add an option to the list. 

This allows addons to create and ship icon texture sets that users can apply using the dropdown instead of having to paste in a custom texture path.