### PR TITLE
Fix Custom Icon

### DIFF
--- a/frames/window_main.lua
+++ b/frames/window_main.lua
@@ -4806,6 +4806,7 @@ function Details:InstanceRefreshRows(instance)
 	--icons
 	local no_icon = self.row_info.no_icon
 	local start_after_icon = self.row_info.start_after_icon
+	local start_after_icon_offset_x = 2
 	local isDesaturated = self.row_info.icon_grayscale
 	local icon_offset_x, icon_offset_y = unpack(self.row_info.icon_offset)
 	local iconMask = self.row_info.icon_mask
@@ -4879,7 +4880,12 @@ function Details:InstanceRefreshRows(instance)
 				row.icone_classe:Show()
 
 				if (start_after_icon) then
-					row.statusbar:SetPoint("topleft", row.icone_classe, "topright")
+					row.statusbar:ClearAllPoints()
+					row.statusbar:SetPoint("left", row.icone_classe, "right", start_after_icon_offset_x, 0)
+					row.background:ClearAllPoints()
+					row.background:SetAllPoints(row.statusbar)
+					row.overlayTexture:ClearAllPoints()
+					row.overlayTexture:SetAllPoints(row.statusbar)
 				else
 					row.statusbar:SetPoint("topleft", row, "topleft")
 				end
@@ -4918,7 +4924,12 @@ function Details:InstanceRefreshRows(instance)
 				row.icone_classe:Show()
 
 				if (start_after_icon) then
-					row.statusbar:SetPoint("bottomright", row.icone_classe, "bottomleft")
+					row.statusbar:ClearAllPoints()
+					row.statusbar:SetPoint("right", row.icone_classe, "left", -start_after_icon_offset_x, 0)
+					row.background:ClearAllPoints()
+					row.background:SetAllPoints(row.statusbar)
+					row.overlayTexture:ClearAllPoints()
+					row.overlayTexture:SetAllPoints(row.statusbar)
 				else
 					row.statusbar:SetPoint("bottomright", row, "bottomright")
 				end
@@ -5036,6 +5047,8 @@ function Details:InstanceRefreshRows(instance)
 		--backdrop
 		if (lineBorderEnabled) then
 			row.lineBorder:Show()
+			row.lineBorder:ClearAllPoints()
+			row.lineBorder:SetAllPoints(row.statusbar)
 			row.lineBorder:SetVertexColor(unpack(lineBorderColor))
 			row.lineBorder:SetBorderSizes(lineBorderSize, lineBorderSize, lineBorderSize, lineBorderSize)
 			row.lineBorder:UpdateSizes()

--- a/frames/window_main.lua
+++ b/frames/window_main.lua
@@ -7437,6 +7437,7 @@ function Details:ChangeSkin(skin_name)
 	end
 
 	self:UpdateClickThrough()
+	self:ReajustaGump()
 end
 
 --update the window click through state


### PR DESCRIPTION
- Bar Start After Icon now works for Overlay and Background textures too. [b992b04](https://github.com/Tercioo/Details-Damage-Meter/pull/706/commits/b992b046b4e126f37100388687f27af00ca778ca)
- Icon Size Offset is now applied immediately after login/reload. [1582c2f](https://github.com/Tercioo/Details-Damage-Meter/pull/706/commits/1582c2f3be159568d230c12cd38123a7c14ff4f5)