### PR TITLE
Added "IconTexture" to .toc files where missing

### DIFF
--- a/plugins/Details_Compare2/Details_Compare2_Wrath.toc
+++ b/plugins/Details_Compare2/Details_Compare2_Wrath.toc
@@ -2,5 +2,6 @@
 ## Title: Details!: Compare 2.0
 ## Notes: Replace the Compare tab in the player breakdown window.
 ## RequiredDeps: Details
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 Details_Compare2.lua

--- a/plugins/Details_DataStorage/Details_DataStorage-Wrath.toc
+++ b/plugins/Details_DataStorage/Details_DataStorage-Wrath.toc
@@ -5,5 +5,6 @@
 ## LoadOnDemand: 1
 ## Dependencies: Details
 ## SavedVariables: DetailsDataStorage
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 Details_DataStorage.lua

--- a/plugins/Details_DataStorage/Details_DataStorage_Wrath.toc
+++ b/plugins/Details_DataStorage/Details_DataStorage_Wrath.toc
@@ -5,5 +5,6 @@
 ## LoadOnDemand: 1
 ## Dependencies: Details
 ## SavedVariables: DetailsDataStorage
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 Details_DataStorage.lua

--- a/plugins/Details_TinyThreat/Details_TinyThreat.toc
+++ b/plugins/Details_TinyThreat/Details_TinyThreat.toc
@@ -3,6 +3,7 @@
 ## Notes: Threat meter plugin, show threat for group members in the window. Select it from the Plugin menu in the Orange Cogwheel.
 ## RequiredDeps: Details
 ## OptionalDeps: Ace3
+## IconTexture: Interface\AddOns\Details\images\minimap
 
 ## X-Wago-ID: Rn6VJW6d
 


### PR DESCRIPTION
Found one plugin where the `IconTexture` was missing, went through the plugins and added where missing

Before:
![Wow_xZ4hiAnwsF](https://github.com/Tercioo/Details-Damage-Meter/assets/1754678/fa0c525f-1bd1-4aca-a211-d571fcb4885d)

After:
![Wow_xof7ZoXhy1](https://github.com/Tercioo/Details-Damage-Meter/assets/1754678/380addf0-a2a0-4848-aae7-472730e0fbec)
