### PR TITLE
Fix dashes and spaces in player realm name

### DIFF
--- a/core/parser.lua
+++ b/core/parser.lua
@@ -6199,7 +6199,7 @@ local SPELL_POWER_PAIN = SPELL_POWER_PAIN or (PowerEnum and PowerEnum.Pain) or 1
 
 		local _, _, _, toc = GetBuildInfo()
 		if (toc >= 100200) then
-			Details.playername = UnitName("player") .. "-" .. (GetRealmName():gsub("%s", ''))
+			Details.playername = UnitName("player") .. "-" .. (GetRealmName():gsub("[%s-]", ''))
 		else
 			Details.playername = UnitName("player")
 		end


### PR DESCRIPTION
Blizzard Ambiguate function doesn't like there being spaces or dashes in the input provided. Removes both from the player name.