### PR TITLE
Added an option to Keep Mythic+ Overall Segments to the automatic erase data dialog.

### DIFF
--- a/core/control.lua
+++ b/core/control.lua
@@ -1866,7 +1866,7 @@
 		local panel = _G.DetailsEraseDataConfirmation
 		if (not panel) then
 			panel = CreateFrame("frame", "DetailsEraseDataConfirmation", UIParent, "BackdropTemplate")
-			panel:SetSize(400, 85)
+			panel:SetSize(600, 85)
 			panel:SetPoint("center", UIParent)
 
 			DetailsFramework:AddRoundedCornersToFrame(panel, Details.PlayerBreakdown.RoundedCornerPreset)
@@ -1900,6 +1900,11 @@
 			local yes = Details.gump:CreateButton(panel, function() panel:Hide(); Details.tabela_historico:ResetAllCombatData() end, 90, 20, Loc ["STRING_YES"])
 			yes:SetPoint("bottomright", panel, "bottomright", -30, 10)
 			yes:InstallCustomTexture(nil, nil, nil, nil, true)
+
+			local keepMythicPlus = Details.gump:CreateButton(panel, function() panel:Hide(); Details.tabela_historico:ResetDataByCombatType("m+overall") end, 90, 20, Loc ["STRING_OPTIONS_KEEP_MYTHICPLUS_OVERALL"])
+			keepMythicPlus:SetPoint("center", panel, "center")
+			keepMythicPlus:SetPoint("bottom", panel, "bottom", 0, 10)
+			keepMythicPlus:InstallCustomTexture(nil, nil, nil, nil, true)
 		end
 
 		panel:Show()

--- a/locales/Details-enUS.lua
+++ b/locales/Details-enUS.lua
@@ -627,6 +627,7 @@ L["STRING_OPTIONS_COMBAT_ALPHA_DESC"] = [=[Select how combat affects the window 
 L["STRING_OPTIONS_COMBATTWEEKS"] = "Combat Tweaks"
 L["STRING_OPTIONS_COMBATTWEEKS_DESC"] = "Behavioral adjustments on how Details! deal with some combat aspects."
 L["STRING_OPTIONS_CONFIRM_ERASE"] = "Do you want to erase data?"
+L["STRING_OPTIONS_KEEP_MYTHICPLUS_OVERALL"] = "Yes, but keep Mythic+ Overall Segments"
 L["STRING_OPTIONS_CUSTOMSPELL_ADD"] = "Add Spell"
 L["STRING_OPTIONS_CUSTOMSPELLTITLE"] = "Edit Spell Settings"
 L["STRING_OPTIONS_CUSTOMSPELLTITLE_DESC"] = "This panel alows you modify the name and icon of spells."
@@ -1715,5 +1716,6 @@ L["STRING_WIPE_ERROR1"] = "a wipe already has been call."
 L["STRING_WIPE_ERROR2"] = "we aren't in a raid encounter."
 L["STRING_WIPE_ERROR3"] = "couldn't end the encounter."
 L["STRING_YES"] = "Yes"
+L["STRING_RESET_KEEP_MYTHICPLUS_OVERALL"] = "Reset, but keep Mythic+ Overall Segments"
 
 --@localization(locale="enUS", format="lua_additive_table")@


### PR DESCRIPTION
Added a third button to the Automatic Erase data confirmation dialog that appears when entering a new instance which allows keeping the overall mythic+ data, just like the existing option to do the same in the erase menu.