### PR TITLE
Restrict !!WWAddOnsFix from being active alongside Details. 

### DIFF
--- a/boot.lua
+++ b/boot.lua
@@ -1806,3 +1806,37 @@ function Details:DestroyActor(actorObject, actorContainer, combatObject, callSta
 	actorObject.__destroyed = true
 	actorObject.__destroyedBy = debugstack(callStackDepth or 2, 1, 0)
 end
+
+local restrictedAddons = {
+    '!!WWAddOnsFix',
+}
+
+local restrictedAddonFrame = CreateFrame('frame')
+restrictedAddonFrame:RegisterEvent('PLAYER_ENTERING_WORLD')
+
+local function disableRestrictedAddons()
+    for _, addonName in pairs(restrictedAddons) do
+        print(addonName)
+        if C_AddOns.GetAddOnEnableState(addonName) ~= 0 then
+            StaticPopupDialogs["DETAILS_RESTRICTED_ADDON"] = {
+                text = "You are running " .. addonName .. " which is incompatible with Details! Damage Meter. It must be disabled for Details to function properly.",
+                button1 = "Disable " .. addonName,
+                button2 = "Disable Details!",
+                OnAccept = function()
+                    C_AddOns.DisableAddOn(addonName)
+                    ReloadUI()
+                 end,
+                OnCancel = function()
+                    C_AddOns.DisableAddOn('Details')
+                    ReloadUI()
+                end,
+                timeout = 0,
+                whileDead = true,
+            }
+            StaticPopup_Show("DETAILS_RESTRICTED_ADDON")
+            break
+        end
+    end
+end
+
+restrictedAddonFrame:SetScript('OnEvent', function() C_Timer.After(2, disableRestrictedAddons) end )


### PR DESCRIPTION
Add handling to check against restricted addons that are run alongside Details. Currently just the !!WWAddOnsFix "addon" that now causes errors when it is active, But the handling is there in case any other ones crop up that are problematic in the future.