### PR TITLE
Disable resource breakdowns

### DIFF
--- a/classes/class_resources.lua
+++ b/classes/class_resources.lua
@@ -1227,6 +1227,8 @@ end
 
 function atributo_energy:MontaDetalhesRegenRecebido (nome, barra)
 
+    if true then return end
+
 	reset_tooltips_table()
 
 	local barras = breakdownWindowFrame.barras3

--- a/frames/window_main.lua
+++ b/frames/window_main.lua
@@ -1961,7 +1961,8 @@ local lineScript_Onmouseup = function(self, button)
 
 	if (self.mouse_down and (self.mouse_down+0.4 > GetTime() and (x == self.x and y == self.y)) or (x == self.x and y == self.y)) then
 		if (self.button == "LeftButton" or self.button == "MiddleButton") then
-			if (instanceObject.atributo == 5 or bIsShiftDown) then
+            --Temporary disabling of Resource breakdowns since not implemented
+			if (instanceObject.atributo == 5 or instanceObject.atributo == 3 or bIsShiftDown) then
 				--report
 				if (instanceObject.atributo == 5 and bIsShiftDown) then
 					local custom = instanceObject:GetCustomObject()


### PR DESCRIPTION
class_resources breakdowns open up the breakdown window completely blank. Even though they're not implemented yet for the new breakdown.