### PR TITLE
Rewrite get pet owner

### DIFF
--- a/classes/container_actors.lua
+++ b/classes/container_actors.lua
@@ -199,7 +199,7 @@ end
 
         local ownerGUID, ownerName, lineText
 
-		local cbMode = tonumber(GetCVar("colorblindMode")) or 0
+        local cbMode = tonumber(GetCVar("colorblindMode")) or 0
         if (bIsDragonflightOrAbove) then
             local tooltipData = C_TooltipInfo.GetHyperlink('unit:'.. petGUID)
             if (tooltipData) then


### PR DESCRIPTION
Uses current handling for getting GUID from tooltip for retail. On no GUID then use the name line and check against raid_roster.
For classic, use the TextLeft line that correlates to the name of the unit.