### PR TITLE
Add check for lineTwo not existing in GetPetOwner

### DIFF
--- a/classes/container_actors.lua
+++ b/classes/container_actors.lua
@@ -207,7 +207,12 @@ end
                     ownerGUID = tooltipData.guid
                 elseif (tooltipData.lines[1].leftText == petName) then
                     local lineTwo = tooltipData.lines[2 + cbMode]
-                    if (lineTwo.type == 16 and lineTwo.guid) then
+                    if (not lineTwo) then
+                        if (Details222.Debug.DebugPets or Details222.Debug.DebugPlayerPets) then
+					        Details:Msg("DebugPets|ActorContainer|Tooltip No LineTwo|PetName:", petName, "PetGUID:", petGUID, "ColorblindMode:", cbMode)
+                        end
+                        return
+                    elseif (lineTwo.type == 16 and lineTwo.guid) then
                         ownerGUID = lineTwo.guid
                     else
                         lineText = lineTwo.leftText


### PR DESCRIPTION
Sometimes LineTwo will not exist for some reason, I suspect it's due to the same reason we weren't finding monk SEF, (Pet getting buffed before fully loading). I added a debug print statement just to add some info if we need to find it due to something maybe happenening that's causing a specific pet not to be found. 