### PR TITLE
Augbuff reattribution

### DIFF
--- a/core/parser.lua
+++ b/core/parser.lua
@@ -6972,9 +6972,9 @@ local SPELL_POWER_PAIN = SPELL_POWER_PAIN or (PowerEnum and PowerEnum.Pain) or 1
 				
 				if (Details.cached_specs[unitGUID] == 1473) then
 					if (unitGUID == playerGUID) then
-						table.insert(aug_members_cache, {unitGUID, unitName, "1297"})
+						table.insert(aug_members_cache, {unitGUID, unitName, 0x511})
 					else
-						table.insert(aug_members_cache, {unitGUID, unitName, "1298"})
+						table.insert(aug_members_cache, {unitGUID, unitName, 0x512})
 					end
 				end
 			end
@@ -7002,9 +7002,9 @@ local SPELL_POWER_PAIN = SPELL_POWER_PAIN or (PowerEnum and PowerEnum.Pain) or 1
 				
 				if (Details.cached_specs[unitGUID] == 1473) then
 					if (unitGUID == playerGUID) then
-						table.insert(aug_members_cache, {unitGUID, unitName, "1297"})
+						table.insert(aug_members_cache, {unitGUID, unitName, 0x511})
 					else
-						table.insert(aug_members_cache, {unitGUID, unitName, "1298"})
+						table.insert(aug_members_cache, {unitGUID, unitName, 0x512})
 					end
 				end
 			end
@@ -7013,7 +7013,11 @@ local SPELL_POWER_PAIN = SPELL_POWER_PAIN or (PowerEnum and PowerEnum.Pain) or 1
 			local unitIdExtra = unitIdCache[GetNumGroupMembers()]
 			local unitGUIDExtra = UnitGUID(unitIdExtra)
 			if (Details.cached_specs[unitGUIDExtra] == 1473) then
-				table.insert(aug_members_cache, {unitGUID, unitName, "1298"})
+				if (unitGUID == playerGUID) then
+					table.insert(aug_members_cache, {unitGUIDExtra, unitNameExtra, 0x511})
+				else
+					table.insert(aug_members_cache, {unitGUIDExtra, unitNameExtra, 0x512})
+				end
 			end
 
 			--player
@@ -7054,7 +7058,7 @@ local SPELL_POWER_PAIN = SPELL_POWER_PAIN or (PowerEnum and PowerEnum.Pain) or 1
 			end
 				
 			if (Details.cached_specs[playerGUID] == 1473) then
-				table.insert(aug_members_cache, {unitGUID, unitName, "1297"})
+				table.insert(aug_members_cache, {unitGUID, unitName, 0x511})
 			end
 		end
 


### PR DESCRIPTION
Reattributes damage from Fate Mirror, Inferno's Blessing, Breath of Eons, and Blistering Scales to the casting Augmentation Evoker directly, instead of using the augmented spells container / "grey bar".
Added reattribution for Fate Mirror healing.
Added an extra bar (same as Neltharus Weapons), "Unknown Buffer", for when multiple Augmentation Evokers are buffing the same target and the exact caster cannot be determined.
Added reattribution for Thread of Fate damage and healing.
Added reattribution for Blessing of Summer healing.
Removed reattribution for Blessing of Winter damage, as it no longer does damage.