### PR TITLE
Ignore scarab overhealing

### DIFF
--- a/core/parser.lua
+++ b/core/parser.lua
@@ -2366,6 +2366,7 @@
 		[86273] = true, -- Illuminated Healing
 		[114908] = true, --Spirit Shell
 		[152118] = true, --Clarity of Will
+        [447134] = true, --Ravenous Scarab
 	}
 
 	function parser:heal_denied(token, time, sourceSerial, sourceName, sourceFlags, targetSerial, targetName, targetFlags, targetFlags2, spellIdAbsorb, spellNameAbsorb, spellSchoolAbsorb, serialHealer, nameHealer, flagsHealer, flags2Healer, spellIdHeal, spellNameHeal, typeHeal, amountDenied)


### PR DESCRIPTION
The trinket "Ravenous Scarab" applies a buff that gets refreshed as you take damage to specify how much it has remaining. It does not replace the old values, so it needs to be ignored for overhealing calculations.