### PR TITLE
Fix issues with UnitIdCache.Party

### DIFF
--- a/core/parser.lua
+++ b/core/parser.lua
@@ -5772,7 +5772,7 @@ local SPELL_POWER_PAIN = SPELL_POWER_PAIN or (PowerEnum and PowerEnum.Pain) or 1
 
 			elseif (IsInGroup()) then
 				local unitIdCache = Details222.UnitIdCache.Party
-				for i = 1, 4 do
+				for i = 1, 5 do
 					local unitId = unitIdCache[i]
 					local guid = UnitGUID(unitId)
 					if (guid) then
@@ -6953,7 +6953,7 @@ local SPELL_POWER_PAIN = SPELL_POWER_PAIN or (PowerEnum and PowerEnum.Pain) or 1
 
 		elseif (IsInGroup()) then
 			local unitIdCache = Details222.UnitIdCache.Party
-			for i = 1, GetNumGroupMembers()-1 do
+			for i = 1, GetNumGroupMembers() do
 				local unitId = unitIdCache[i]
 
 				local unitName = GetUnitName(unitId, true)

--- a/core/util.lua
+++ b/core/util.lua
@@ -1288,7 +1288,7 @@ end
 
 		elseif (IsInGroup()) then
 			local unitIdCache = Details222.UnitIdCache.Party
-			for i = 1, GetNumGroupMembers()-1, 1 do
+			for i = 1, GetNumGroupMembers(), 1 do
 				if (UnitAffectingCombat(unitIdCache[i])) then
 					return true
 				end


### PR DESCRIPTION
UnitIdCache.Party also includes the Player unitID, by looping one less then you're missing whoever is party4