### PR TITLE
fix: updating some missing and currently incorrect crowd control spells for cata classic

### DIFF
--- a/Libs/LibOpenRaid/ThingsToMantain_Cata.lua
+++ b/Libs/LibOpenRaid/ThingsToMantain_Cata.lua
@@ -512,6 +512,7 @@ LIB_OPEN_RAID_CROWDCONTROL = { --copied from retail
 	[161353] = {cooldown = 0,	class = "MAGE"}, --Polymorph
 	[277787] = {cooldown = 0,	class = "MAGE"}, --Polymorph
 	[157981] = {cooldown = 30,	class = "MAGE"}, --Blast Wave
+	[44572] = {cooldown = 0,	class = "MAGE"}, --Deep Freeze
 	[82691] = {cooldown = 0,	class = "MAGE"}, --Ring of Frost
 	[118] = {cooldown = 0,		class = "MAGE"}, --Polymorph
 	[161354] = {cooldown = 0,	class = "MAGE"}, --Polymorph

--- a/Libs/LibOpenRaid/ThingsToMantain_Cata.lua
+++ b/Libs/LibOpenRaid/ThingsToMantain_Cata.lua
@@ -572,7 +572,6 @@ LIB_OPEN_RAID_CROWDCONTROL = { --copied from retail
 	[6789] = {cooldown = 45,	class = "WARLOCK"}, --Mortal Coil
 	[118699] = {cooldown = 0,	class = "WARLOCK"}, --Fear
 	[5782] = {cooldown = 0,	class = "WARLOCK"}, --Fear
-    [5484] = {cooldown = 0,	class = "WARLOCK"}, --Howl Of Terror
 	[710] = {cooldown = 0,		class = "WARLOCK"}, --Banish
 	[212619] = {cooldown = 60,	class = "WARLOCK"}, --Call Felhunter
 	[19647] = {cooldown = 24,	class = "WARLOCK"}, --Spell Lock

--- a/Libs/LibOpenRaid/ThingsToMantain_Cata.lua
+++ b/Libs/LibOpenRaid/ThingsToMantain_Cata.lua
@@ -174,6 +174,7 @@ LIB_OPEN_RAID_COOLDOWNS_INFO = {
 	[116705] = {class = "MONK", specs = {268, 269}, cooldown = 15, silence = 4, talent = false, cooldownWithTalent = false, cooldownTalentId = false, type = 6, charges = 1}, --Spear Hand Strike (brewmaster and windwalker)
 	[57994] = {class = "SHAMAN", specs = {262, 263, 264}, cooldown = 12, silence = 3, talent = false, cooldownWithTalent = false, cooldownTalentId = false, type = 6, charges = 1}, --Wind Shear
 	[47528] = {class = "DEATHKNIGHT", specs = {250, 251, 252}, cooldown = 15, silence = 3, talent = false, cooldownWithTalent = false, cooldownTalentId = false, type = 6, charges = 1}, --Mind Freeze
+	[47476] = {class = "DEATHKNIGHT", specs = {250, 251, 252}, cooldown = 120, silence = 3, talent = false, cooldownWithTalent = false, cooldownTalentId = false, type = 6, charges = 1}, --Strangulate
 	[106839] = {class = "DRUID", specs = {103, 104}, cooldown = 15, silence = 4, talent = false, cooldownWithTalent = false, cooldownTalentId = false, type = 6, charges = 1}, --Skull Bash (feral, guardian)
 	[78675] = {class = "DRUID", specs = {102}, cooldown = 60, silence = 8, talent = false, cooldownWithTalent = false, cooldownTalentId = false, type = 6, charges = 1}, --Solar Beam (balance)
 	[147362] = {class = "HUNTER", specs = {253, 254}, cooldown = 24, silence = 3, talent = false, cooldownWithTalent = false, cooldownTalentId = false, type = 6, charges = 1}, --Counter Shot (beast mastery, marksmanship)
@@ -469,6 +470,7 @@ LIB_OPEN_RAID_CROWDCONTROL = { --copied from retail
 	[334693] = {cooldown = 0,	class = "DEAHTKNIGHT"}, --Absolute Zero
 	[221562] = {cooldown = 45,	class = "DEATHKNIGHT"}, --Asphyxiate
 	[47528] = {cooldown = 15,	class = "DEATHKNIGHT"}, --Mind Freeze
+	[47476] = {cooldown = 120,  class = "DEAHTKNIGHT"}, --Strangulate
 	[207167] = {cooldown = 60,	class = "DEATHKNIGHT"}, --Blinding Sleet
 	[91807] = {cooldown = 0,	class = "DEATHKNIGHT"}, --Shambling Rush
 	[108194] = {cooldown = 45,	class = "DEATHKNIGHT"}, --Asphyxiate
@@ -657,6 +659,7 @@ LIB_OPEN_RAID_SPELL_INTERRUPT = {
 	[57994] = LIB_OPEN_RAID_COOLDOWNS_INFO[57994], --Wind Shear
 
 	[47528] = LIB_OPEN_RAID_COOLDOWNS_INFO[47528], --Mind Freeze
+	[47476] = LIB_OPEN_RAID_COOLDOWNS_INFO[47476], --Strangulate
 
 	[106839] = LIB_OPEN_RAID_COOLDOWNS_INFO[106839], --Skull Bash (feral, guardian)
 	[78675] = LIB_OPEN_RAID_COOLDOWNS_INFO[78675], --Solar Beam (balance)

--- a/Libs/LibOpenRaid/ThingsToMantain_Cata.lua
+++ b/Libs/LibOpenRaid/ThingsToMantain_Cata.lua
@@ -268,7 +268,7 @@ LIB_OPEN_RAID_COOLDOWNS_INFO = {
 	[192058] = 	{cooldown = 60, 	duration = false, 	specs = {262,263,264}, 	talent =false, charges = 1, class = "SHAMAN", type = 5}, --Capacitor Totem
 	[8143] = 	{cooldown = 60, 	duration = 10, 		specs = {262,263,264}, 	talent =false, charges = 1, class = "SHAMAN", type = 5}, --Tremor Totem
 	[192077] = 	{cooldown = 120, 	duration = 15, 		specs = {262,263,264}, 	talent =21966, charges = 1, class = "SHAMAN", type = 5}, --Wind Rush Totem (talent)
-	
+
 	--monk
 	-- 268 - Brewmaster
 	-- 269 - Windwalker
@@ -292,7 +292,7 @@ LIB_OPEN_RAID_COOLDOWNS_INFO = {
 	[197908] = 	{cooldown = 90, 	duration = 10, 		specs = {270}, 			talent =22166, charges = 1, class = "MONK", type = 5}, --Mana tea (talent)
 	[116844] = 	{cooldown = 45, 	duration = 5, 		specs = {268,269,270}, 	talent =19995, charges = 1, class = "MONK", type = 5}, --Ring of peace (talent)
 	[119381] = 	{cooldown = 50, 	duration = 3, 		specs = {268,269,270}, 	talent =false, charges = 1, class = "MONK", type = 5}, --Leg Sweep
-	
+
 	--hunter
 	-- 253 - Beast Mastery
 	-- 254 - Marksmenship
@@ -381,7 +381,7 @@ LIB_OPEN_RAID_COOLDOWNS_INFO = {
 	[207684] = 	{cooldown = 90, 	duration = 12, 		specs = {581}, 			talent =false, charges = 1, class = "DEMONHUNTER", type = 5}, --Sigil of Misery
 	[202137] = 	{cooldown = 60, 	duration = 8, 		specs = {581}, 			talent =false, charges = 1, class = "DEMONHUNTER", type = 5}, --Sigil of Silence
 	[202138] = 	{cooldown = 90, 	duration = 6, 		specs = {581}, 			talent =22511, charges = 1, class = "DEMONHUNTER", type = 5}, --Sigil of Chains (talent)
-	
+
 	--mage
 	-- 62 - Arcane
 	-- 63 - Fire
@@ -484,7 +484,7 @@ LIB_OPEN_RAID_CROWDCONTROL = { --copied from retail
 	[93985] = {cooldown = 0,	class = "DRUID"}, --Skull Bash
 	[2637] = {cooldown = 0,		class = "DRUID"}, --Hibernate
 	[5211] = {cooldown = 60,	class = "DRUID"}, --Mighty Bash
-	[99] = {cooldown = 30,		class = "DRUID"}, --Incapacitating Roar
+	[22570] = {cooldown = 10,       class = "DRUID"}, --Maim
 	[127797] = {cooldown = 0,	class = "DRUID"}, --Ursol's Vortex
 	[203123] = {cooldown = 0,	class = "DRUID"}, --Maim
 	[45334] = {cooldown = 0,	class = "DRUID"}, --Immobilized
@@ -504,6 +504,8 @@ LIB_OPEN_RAID_CROWDCONTROL = { --copied from retail
 	[117405] = {cooldown = 0,	class = "HUNTER"}, --Binding Shot
 	[19577] = {cooldown = 60,	class = "HUNTER"}, --Intimidation
 	[1513] = {cooldown = 0,		class = "HUNTER"}, --Scare Beast
+    [90337] = {cooldown = 60,	class = "HUNTER"}, --Bad Manner (Monkey Stun)
+    [19503] = {cooldown = 30,	class = "HUNTER"}, --Scatter Shot
 	[3355] = {cooldown = 30,	class = "HUNTER"}, --Freezing Trap
 	[203337] = {cooldown = 30,	class = "HUNTER"}, --Freezing trap with diamond ice talent
 	[31661] = {cooldown = 45,	class = "MAGE"}, --Dragon's Breath

--- a/Libs/LibOpenRaid/ThingsToMantain_Cata.lua
+++ b/Libs/LibOpenRaid/ThingsToMantain_Cata.lua
@@ -571,6 +571,8 @@ LIB_OPEN_RAID_CROWDCONTROL = { --copied from retail
 	[89766] = {cooldown = 30,	class = "WARLOCK"}, --Axe Toss (pet felguard ability)
 	[6789] = {cooldown = 45,	class = "WARLOCK"}, --Mortal Coil
 	[118699] = {cooldown = 0,	class = "WARLOCK"}, --Fear
+	[5782] = {cooldown = 0,	class = "WARLOCK"}, --Fear
+    [5484] = {cooldown = 0,	class = "WARLOCK"}, --Howl Of Terror
 	[710] = {cooldown = 0,		class = "WARLOCK"}, --Banish
 	[212619] = {cooldown = 60,	class = "WARLOCK"}, --Call Felhunter
 	[19647] = {cooldown = 24,	class = "WARLOCK"}, --Spell Lock


### PR DESCRIPTION
## For Cata Classic

Remove:
* Incapacitating Roar as it's not a CC in cata

Add:
* Maim
* Bad Manner
* Scatter Shot
* Fear
* Deep Freeze
* Strangulate