### PR TITLE
Added Kelpfist to ScrollDamage window

### DIFF
--- a/frames/window_scrolldamage.lua
+++ b/frames/window_scrolldamage.lua
@@ -308,6 +308,7 @@ local targetDummiesIds = {
 	[225982] = true, --Cleave Dummy - Dornogal
 	[225977] = true, --Dungeoneer's Tanking dummy - Dornogal
 	[225976] = true, --Normal Tanking dummy - Dornogal
+	[225985] = true, --Kelpfist - Dornogal 
 }
 
 targetDummieHandle:SetScript("OnEvent", function(_, _, unit)


### PR DESCRIPTION
A few guildies have expressed interest in Kelpfist being a target for the scrolldamage window, so a small one liner here

It is possible that Kelpfist was intentionally not added to the list due to not wanting to trigger the window, but could find no evidence of that, so tossed my change here incase it was wanted to be mainlined

Cheers
lunarised