### PR TITLE
Fix nil error where object is expected

### DIFF
--- a/core/parser.lua
+++ b/core/parser.lua
@@ -5541,9 +5541,6 @@ local SPELL_POWER_PAIN = SPELL_POWER_PAIN or (PowerEnum and PowerEnum.Pain) or 1
 			Details:Msg("(debug) |cFFFFFF00ENCOUNTER_START|r event triggered.")
 		end
 
-		Details:Destroy(Details.CLEUEventAmount)
-		Details:Destroy(Details.CLEUEventTime)
-
 		Details222.Perf.WindowUpdate = 0
 		Details222.Perf.WindowUpdateC = true
 


### PR DESCRIPTION
The CLEUEventAmount and CLEUEventTime were removed from being set in another commit causing Destroy with nil instead of object

The init for these key was removed in https://github.com/Tercioo/Details-Damage-Meter/commit/5b61ccbbc685ba03e8c79c83c7e048776f3a3410#diff-21586fd8903503a5b99b1554cc4cfc0e92aeaaaf1a320937e28c17932d715f23L6886