### PR TITLE
fix(parser): Include pet contributions in group totals

### DIFF
--- a/core/parser.lua
+++ b/core/parser.lua
@@ -1097,10 +1097,9 @@
 			end
 		end
 
-		if (sourceActor.grupo and not sourceActor.arena_enemy and not sourceActor.enemy and not targetActor.arena_enemy) then --source = friendly player and not an enemy player
-			--dano to adversario estava caindo aqui por nao estar checando .enemy
+		if ((sourceActor.grupo or (sourceActor.owner and sourceActor.owner.grupo)) and not sourceActor.arena_enemy and not sourceActor.enemy and not targetActor.arena_enemy) then --source = friendly player/pet and not an enemy player 
+			--dano to adversario estava caindo aqui por nao estar checando .enemy 
 			_current_gtotal[1] = _current_gtotal[1] + amount
-
 		elseif (targetActor.grupo) then --source = arena enemy or friendly player
 			if (targetActor.arena_enemy) then
 				_current_gtotal[1] = _current_gtotal[1] + amount


### PR DESCRIPTION
## Problem
fix #926 

## Solution
Optimized the damage parsing logic in `parser.lua` to include pet contributions in group totals

## Screenshot
### Before
![Image](https://github.com/user-attachments/assets/9860abf1-d404-44dc-aa4a-92f8742acb01)
### After
![after](https://github.com/user-attachments/assets/e706a994-dfde-4ffc-98cc-48a0d3965f12)
