### PR TITLE
Always enable the M+ overall score

### DIFF
--- a/frames/window_options2_sections.lua
+++ b/frames/window_options2_sections.lua
@@ -7032,16 +7032,6 @@ do
                 desc = Loc["STRING_OPTIONS_MPLUS_BOSSNEWCOMBAT_DESC"],
             },
 
-            {--make overall when done
-                type = "toggle",
-                get = function() return Details.mythic_plus.make_overall_when_done end,
-                set = function(self, fixedparam, value)
-                    Details.mythic_plus.make_overall_when_done = value
-                end,
-                name = Loc["STRING_OPTIONS_MPLUS_MAKEOVERALL"],
-                desc = Loc["STRING_OPTIONS_MPLUS_MAKEOVERALL_DESC"],
-            },
-
             {--merge trash
                 type = "toggle",
                 get = function() return Details.mythic_plus.merge_boss_trash end,

--- a/functions/mythicdungeon/mythicdungeon.lua
+++ b/functions/mythicdungeon/mythicdungeon.lua
@@ -100,7 +100,7 @@ function DetailsMythicPlusFrame.MythicDungeonFinished(bFromZoneLeft)
         end
 
         --merge segments
-        if (Details.mythic_plus.make_overall_when_done and not Details.MythicPlus.IsRestoredState) then -- and not bFromZoneLeft
+        if (not Details.MythicPlus.IsRestoredState) then -- and not bFromZoneLeft
             if (DetailsMythicPlusFrame.DevelopmentDebug) then
                 print("Details!", "MythicDungeonFinished() > not in combat, creating overall segment now")
             end

--- a/functions/profiles.lua
+++ b/functions/profiles.lua
@@ -1660,7 +1660,6 @@ local default_global_data = {
 		mythic_plus = {
 			merge_boss_trash = true,
 			boss_dedicated_segment = true,
-			make_overall_when_done = true,
 			make_overall_boss_only = false,
 			show_damage_graphic = true,
 
@@ -2083,7 +2082,6 @@ function Details:ImportProfile (profileString, newProfileName, bImportAutoRunCod
 		local mythicPlusSettings = Details.mythic_plus
 		mythicPlusSettings.merge_boss_trash = true
 		mythicPlusSettings.boss_dedicated_segment = true
-		mythicPlusSettings.make_overall_when_done = true
 		mythicPlusSettings.make_overall_boss_only = false
 		mythicPlusSettings.show_damage_graphic = true
 		mythicPlusSettings.reverse_death_log = false


### PR DESCRIPTION
Disabling this setting doesn't make sense in M+ and breaks the M+ addon as it no longer gets all the information.