### PR TITLE
Add Details to Blizzard's Addon Compartment

### DIFF
--- a/Details.toc
+++ b/Details.toc
@@ -8,6 +8,7 @@
 ## OptionalDeps: Ace3, LibSharedMedia-3.0, LibWindow-1.1, LibDBIcon-1.0, NickTag-1.0, LibDataBroker-1.1, LibGraph-2.0
 ## Version: #@project-version@
 ## IconTexture: Interface\AddOns\Details\images\minimap
+## AddonCompartmentFunc: Details_OpenDefaultOptionsWindow
 
 ## X-Curse-Project-ID: 61284
 ## X-Wago-ID: qv63A7Gb

--- a/frames/window_options2.lua
+++ b/frames/window_options2.lua
@@ -463,6 +463,18 @@ function Details:OpenOptionsWindow(instance, bNoReopen, section)
     DetailsPluginContainerWindowMenuFrame:SetColor(unpack(Details.frame_background_color))
 end
 
+---open the default options window, used for the addon compartment
+function Details_OpenDefaultOptionsWindow()
+    local lower_instance = Details:GetLowerInstanceNumber()
+    if (not lower_instance) then
+        local instance = Details:GetInstance(1)
+        Details.CriarInstancia (_, _, 1)
+        Details:OpenOptionsWindow (instance)
+    else
+        Details:OpenOptionsWindow (Details:GetInstance(lower_instance))
+    end
+end
+
 function Details:OpenOptionsPanel(instance, bNoReopen, section) --alias
     Details:OpenOptionsWindow(instance, bNoReopen, section)
 end


### PR DESCRIPTION
Addresses #929

Very simple approach: it just opens the menu, just as the default behavior of the minimap button.