### PR TITLE
Publish releases on GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
 env:
   CF_API_KEY: ${{ secrets.CF_API_KEY }}
   WAGO_API_TOKEN: ${{ secrets.WAGO_API_TOKEN }}
+  GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   release: # "release" is a job, you can name it anything you want
@@ -18,5 +19,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # reads history for commit changelog
+
+      - name: Hack around https://github.com/actions/checkout/issues/290
+        run: |
+          git fetch --tags --force
 
       - uses: BigWigsMods/packager@v2


### PR DESCRIPTION
This enables automatic upload of releases to GitHub (along with the pre-existing CurseForge and Wago uploads).
The changes I made are consistent with the way Plater does it, and it should start working automatically when the next tag is created.

I tested it by creating a tag on my forked repo, and installing the resulting release with CurseBreaker (which afaik is the only way to update addons on Linux that isn't a massive pita, and the main motivation for this PR), which seemingly worked fine in WoW.

Related issues:
https://github.com/Tercioo/Details-Damage-Meter/issues/306
https://github.com/Tercioo/Details-Damage-Meter/issues/309
https://github.com/Tercioo/Details-Damage-Meter/issues/434