### PR TITLE
Refresh skin on all windows, fixes custom header texture display

### DIFF
--- a/startup.lua
+++ b/startup.lua
@@ -998,4 +998,3 @@ function Details222.StartUp.StartMeUp()
 end
 
 Details.AddOnLoadFilesTime = _G.GetTime()
-


### PR DESCRIPTION
Unsure why exactly, but this line was refreshing the skin for every window, except for the header, causing custom header textures to not load properly.

Changing this refresh to also refresh the header solves that issue and custom header textures load properly again, resolves this open issue #1015 