### PR TITLE
Fix FadeHandler nil value error in util.lua

### DIFF
--- a/functions/util.lua
+++ b/functions/util.lua
@@ -499,6 +499,10 @@
 
 	Details.FadeHandler.OnUpdateFrame = CreateFrame("frame", "DetailsFadeFrameOnUpdate", UIParent)
 	Details.FadeHandler.OnUpdateFrame:SetScript("OnUpdate", function(self, deltaTime)
+		if (not Details.FadeHandler or not Details.FadeHandler.frames) then
+			return
+		end
+		
 		for frame, frameSettings in pairs(Details.FadeHandler.frames) do
 			local totalTime = frameSettings.totalTime
 			local initAlpha = frameSettings.startAlpha


### PR DESCRIPTION
Inteeded to fix #1050 #1048 #1046

Add nil check for Details.FadeHandler and Details.FadeHandler.frames in OnUpdate script to prevent 'attempt to index field FadeHandler (a nil value)' error. The handler now safely returns early if FadeHandler hasn't been initialized.

OBS: I Made no checks whatsoever if this is safe in for later parts of the code this is just  a "Stupid" skip to avoid the Lua Error