### PR TITLE
Fix Spec/Class Icon in TBC Anni

### DIFF
--- a/Libs/DF/fw.lua
+++ b/Libs/DF/fw.lua
@@ -320,48 +320,50 @@ local roleBySpecTextureName = {
 	DeathKnightUnholy = "DAMAGER",
 }
 
----classic, tbc and wotlk role guesser based on the weights of each talent tree
----@return string
-function DF:GetRoleByClassicTalentTree()
+---returns the talent tab with the most points spent as {name, pointsSpent, fileName, specId}
+---@return table|nil
+local function calculatePlayersSpecByPointsInTree()
 	if (not DF.IsTimewalkWoW()) then
-		return "NONE"
+		return nil
 	end
 
-	--amount of tabs existing
 	local numTabs = GetNumTalentTabs() or 3
-
-	--store the background textures for each tab
 	local pointsPerSpec = {}
 
 	for i = 1, (MAX_TALENT_TABS or 3) do
 		if (i <= numTabs) then
-			--tab information
-			local id, name, description, iconTexture, pointsSpent, fileName = GetTalentTabInfo(i)
+			local specId, name, description, iconTexture, pointsSpent, fileName = GetTalentTabInfo(i)
 			if DF.IsClassicWow() and not fileName then
 				--On pre 1.15.3
-                name, iconTexture, pointsSpent, fileName = id, name, description, iconTexture
+                name, iconTexture, pointsSpent, fileName = specId, name, description, iconTexture
 			end
 			if (name) then
-				table.insert(pointsPerSpec, {name, pointsSpent, fileName})
+				table.insert(pointsPerSpec, {name, pointsSpent, fileName, specId})
 			end
 		end
 	end
 
-	local MIN_SPECS = 4
-
-	--put the spec with more talent point to the top
 	table.sort(pointsPerSpec, function(t1, t2)
 		return t1[2] > t2[2]
 	end)
 
-	--get the spec with more points spent
-	local spec = pointsPerSpec[1]
-	if (spec and spec[2] >= MIN_SPECS) then
-		local specName = spec[1]
-		local spentPoints = spec[2]
-		local specTexture = spec[3]
+	return pointsPerSpec[1]
+end
 
-		local role = roleBySpecTextureName[specTexture]
+---return the specId of the talent tree with the most points spent
+---@return number|nil
+function DF.GetCharacterSpecIdInClassic()
+	local spec = calculatePlayersSpecByPointsInTree()
+	return spec and spec[4]
+end
+
+---classic, tbc and wotlk role guesser based on the weights of each talent tree
+---@return string
+function DF:GetRoleByClassicTalentTree()
+	local MIN_SPECS = 4
+	local spec = calculatePlayersSpecByPointsInTree()
+	if (spec and spec[2] >= MIN_SPECS) then
+		local role = roleBySpecTextureName[spec[3]]
 		return role or "NONE"
 	end
 	return "DAMAGER"
@@ -421,7 +423,7 @@ function DF.UnitGroupRolesAssigned(unitId, bUseSupport, specId)
     end
 
     if (role == "NONE") then
-        if (GetSpecialization) then
+        if (GetSpecialization and not DF.IsTimewalkWoW()) then
             if (UnitIsUnit(unitId, "player")) then
                 local specializationIndex = GetSpecialization() or 0
                 local id, name, description, icon, role, primaryStat = GetSpecializationInfo(specializationIndex)
@@ -1630,9 +1632,9 @@ function DF:AddClassIconToText(text, playerName, englishClassName, useSpec, icon
 		end
 	end
 
-	if (spec and Details.class_specs_coords[spec]) then --if spec is valid, the user has Details! installed
+	if (spec and Details:GetSpecCoords(spec)) then --if spec is valid, the user has Details! installed
 		local specString = ""
-		local L, R, T, B = unpack(Details.class_specs_coords[spec])
+		local L, R, T, B = unpack(Details:GetSpecCoords(spec))
 		if (L) then
 			specString = "|TInterface\\AddOns\\Details\\images\\spec_icons_normal:" .. size .. ":" .. size .. ":0:0:512:512:" .. (L * 512) .. ":" .. (R * 512) .. ":" .. (T * 512) .. ":" .. (B * 512) .. "|t"
 			return specString .. " " .. text

--- a/classes/class_custom.lua
+++ b/classes/class_custom.lua
@@ -763,9 +763,9 @@
 			else
 				if (instanceObject.row_info.use_spec_icons) then
 					local specId = (self.spec and self.spec ~= 0 and self.spec) or (self.my_actor.spec and self.my_actor.spec ~= 0 and self.my_actor.spec)
-					if (specId and _detalhes.class_specs_coords[specId]) then
+					if (specId and Details:GetSpecCoords(specId)) then
 						thisBar.icone_classe:SetTexture(instanceObject.row_info.spec_file)
-						thisBar.icone_classe:SetTexCoord(unpack(Details.class_specs_coords[specId]))
+						thisBar.icone_classe:SetTexCoord(unpack(Details:GetSpecCoords(specId)))
 					else
 						thisBar.icone_classe:SetTexture([[Interface\AddOns\Details\images\classes_small]])
 						thisBar.icone_classe:SetTexCoord(unpack(Details.class_coords[self.classe]))

--- a/classes/class_damage.lua
+++ b/classes/class_damage.lua
@@ -4000,9 +4000,9 @@ function Details:SetClassIcon(texture, instance, class) --[[exported]] --~icons
 	elseif(class == "UNGROUPPLAYER") then
 		if (self.spec) then
 			if (instance and instance.row_info.use_spec_icons) then
-				if (self.spec and Details.class_specs_coords[self.spec]) then
+				if (self.spec and Details:GetSpecCoords(self.spec)) then
 					texture:SetTexture(instance.row_info.spec_file)
-					texture:SetTexCoord(unpack(Details.class_specs_coords[self.spec]))
+					texture:SetTexCoord(unpack(Details:GetSpecCoords(self.spec)))
 					texture:SetVertexColor(1, 1, 1)
 					return
 				end
@@ -4060,9 +4060,9 @@ function Details:SetClassIcon(texture, instance, class) --[[exported]] --~icons
 			if (self.thisSpecIcon) then
 				local specInfo = detailsFramework:GetSpecInfoFromSpecIcon(self.thisSpecIcon)
 				local specId = specInfo and specInfo.specId
-				if (specId and Details.class_specs_coords[specId]) then
+				if (specId and Details:GetSpecCoords(specId)) then
 					texture:SetTexture(instance.row_info.spec_file)
-					texture:SetTexCoord(unpack(Details.class_specs_coords[specId]))
+					texture:SetTexCoord(unpack(Details:GetSpecCoords(specId)))
 					texture:SetVertexColor(1, 1, 1)
 				else
 					texture:SetTexture(self.thisSpecIcon)
@@ -4070,9 +4070,9 @@ function Details:SetClassIcon(texture, instance, class) --[[exported]] --~icons
 					texture:SetVertexColor(1, 1, 1)
 				end
 
-			elseif (self.spec and Details.class_specs_coords[self.spec]) then
+			elseif (self.spec and Details:GetSpecCoords(self.spec)) then
 				texture:SetTexture(instance.row_info.spec_file)
-				texture:SetTexCoord(unpack(Details.class_specs_coords[self.spec]))
+				texture:SetTexCoord(unpack(Details:GetSpecCoords(self.spec)))
 				texture:SetVertexColor(1, 1, 1)
 			else
 				texture:SetTexture(instance.row_info.icon_file or [[Interface\AddOns\Details\images\classes_small]])

--- a/classes/class_utility.lua
+++ b/classes/class_utility.lua
@@ -726,9 +726,9 @@ function atributo_misc:UpdateDeathRow(deathTable, whichRowLine, rankPosition, in
 	if (instanceObject.row_info.use_spec_icons) then
 		local nome = deathTable[3]
 		local spec = instanceObject.showing(1, nome) and instanceObject.showing(1, nome).spec or(instanceObject.showing(2, nome) and instanceObject.showing(2, nome).spec)
-		if (spec and spec ~= 0 and Details.class_specs_coords[spec]) then
+		if (spec and spec ~= 0 and Details:GetSpecCoords(spec)) then
 			thisRow.icone_classe:SetTexture(instanceObject.row_info.spec_file)
-			thisRow.icone_classe:SetTexCoord(unpack(Details.class_specs_coords[spec]))
+			thisRow.icone_classe:SetTexCoord(unpack(Details:GetSpecCoords(spec)))
 		else
 			if (CLASS_ICON_TCOORDS [deathTable[4]]) then
 				thisRow.icone_classe:SetTexture(instanceObject.row_info.icon_file)

--- a/core/gears.lua
+++ b/core/gears.lua
@@ -145,14 +145,19 @@ function Details:ResetSpecCache(forced)
 		Details:Destroy(Details.cached_specs)
 
 		if (Details.track_specs) then
-			local playerSpec = DetailsFramework.GetSpecialization()
-			if (type(playerSpec) == "number") then
-				local specId = DetailsFramework.GetSpecializationInfo(playerSpec)
-				if (type(specId) == "number") then
-					local playerGuid = UnitGUID(Details.playername)
-					if (playerGuid) then
-						Details.cached_specs[playerGuid] = specId
-					end
+			local specId
+			if (DetailsFramework.IsTimewalkWoW()) then
+				specId = DetailsFramework.GetCharacterSpecIdInClassic()
+			else
+				local playerSpec = DetailsFramework.GetSpecialization()
+				if (type(playerSpec) == "number") then
+					specId = DetailsFramework.GetSpecializationInfo(playerSpec)
+				end
+			end
+			if (type(specId) == "number") then
+				local playerGuid = UnitGUID(Details.playername)
+				if (playerGuid) then
+					Details.cached_specs[playerGuid] = specId
 				end
 			end
 		end

--- a/frames/window_breakdown/window_playerbreakdown.lua
+++ b/frames/window_breakdown/window_playerbreakdown.lua
@@ -777,9 +777,9 @@ function breakdownWindowFrame.SetClassIcon(actorObject, class)
 		breakdownWindowFrame.classIcon:SetTexture(actorObject.spellicon)
 		breakdownWindowFrame.classIcon:SetTexCoord(.1, .9, .1, .9)
 
-	elseif (actorObject.spec and _detalhes.class_specs_coords[actorObject.spec]) then
+	elseif (actorObject.spec and Details:GetSpecCoords(actorObject.spec)) then
 		breakdownWindowFrame.classIcon:SetTexture([[Interface\AddOns\Details\images\spec_icons_normal_alpha]])
-		breakdownWindowFrame.classIcon:SetTexCoord(unpack(_detalhes.class_specs_coords[actorObject.spec]))
+		breakdownWindowFrame.classIcon:SetTexCoord(unpack(Details:GetSpecCoords(actorObject.spec)))
 	else
 		local coords = CLASS_ICON_TCOORDS[class]
 		if (coords) then

--- a/frames/window_eventtracker.lua
+++ b/frames/window_eventtracker.lua
@@ -478,7 +478,7 @@ function Details:CreateEventTrackerFrame(parentObject, name)
 
 		local get_player_icon = function(spec, class)
 			if (spec) then
-				return [[Interface\AddOns\Details\images\spec_icons_normal]], unpack(Details.class_specs_coords [spec])
+				return [[Interface\AddOns\Details\images\spec_icons_normal]], unpack(Details:GetSpecCoords(spec))
 			elseif (class) then
 				return [[Interface\AddOns\Details\images\classes_small]], unpack(Details.class_coords [class])
 			else

--- a/frames/window_main.lua
+++ b/frames/window_main.lua
@@ -2225,8 +2225,8 @@ local iconFrame_OnEnter = function(self)
 			local specId, specName, specDescription, specIcon, specRole, specClass = DetailsFramework.GetSpecializationInfoByID(spec or 0) --thanks pas06
 			local specL, specR, specT, specB
 			if (specId) then
-				if (Details.class_specs_coords[specId]) then
-					specL, specR, specT, specB = unpack(Details.class_specs_coords[specId])
+				if (Details:GetSpecCoords(specId)) then
+					specL, specR, specT, specB = unpack(Details:GetSpecCoords(specId))
 				end
 			end
 

--- a/functions/classes.lua
+++ b/functions/classes.lua
@@ -379,9 +379,9 @@ do
 	function Details:AddClassOrSpecIcon(thisString, class, spec, iconSize, useAlphaIcons)
 		iconSize = iconSize or 16
 
-		if (spec and Details.class_specs_coords[spec]) then
+		if (spec and Details:GetSpecCoords(spec)) then
 			local specString = ""
-			local L, R, T, B = unpack(Details.class_specs_coords[spec])
+			local L, R, T, B = unpack(Details:GetSpecCoords(spec))
 			if (L) then
 				if (useAlphaIcons) then
 					specString = "|TInterface\\AddOns\\Details\\images\\spec_icons_normal_alpha:" .. iconSize .. ":" .. iconSize .. ":0:0:512:512:" .. (L * 512) .. ":" .. (R * 512) .. ":" .. (T * 512) .. ":" .. (B * 512) .. "|t"

--- a/functions/playerclass.lua
+++ b/functions/playerclass.lua
@@ -28,7 +28,7 @@ do
 		local instance = Details:GetInstance(1)
 
 		local spec = actorObject:Spec()
-		if (spec and spec > 0 and Details.class_specs_coords[spec]) then
+		if (spec and spec > 0 and Details:GetSpecCoords(spec)) then
 			---@type string
 			local fileName
 
@@ -39,7 +39,7 @@ do
 				fileName = Details.instance_defaults.row_info.spec_file
 			end
 
-			local left, right, top, bottom = unpack(Details.class_specs_coords[spec])
+			local left, right, top, bottom = unpack(Details:GetSpecCoords(spec))
 
 			local textureTable = {
 				texture = fileName,
@@ -204,15 +204,15 @@ do
 	---@param useAlpha boolean
 	---@return string texturePath, number left, number right, number top, number bottom
 	function Details:GetSpecIcon(spec, useAlpha)
-		if (not spec or spec == 0 or not Details.class_specs_coords[spec]) then
+		if (not spec or spec == 0 or not Details:GetSpecCoords(spec)) then
 			--this returns the icon for "unknown" spec (gotten from the class icon file)
 			return [[Interface\AddOns\Details\images\classes_small]], unpack(Details.class_coords["UNKNOW"])
 		end
 
 		if (useAlpha) then
-			return [[Interface\AddOns\Details\images\spec_icons_normal_alpha]], unpack(Details.class_specs_coords [spec])
+			return [[Interface\AddOns\Details\images\spec_icons_normal_alpha]], unpack(Details:GetSpecCoords(spec))
 		else
-			return [[Interface\AddOns\Details\images\spec_icons_normal]], unpack(Details.class_specs_coords[spec])
+			return [[Interface\AddOns\Details\images\spec_icons_normal]], unpack(Details:GetSpecCoords(spec))
 		end
 	end
 
@@ -254,9 +254,9 @@ do
 
 		if (playerObject) then
 			local spec = playerObject.spec
-			if (spec and Details.class_specs_coords[spec]) then
+			if (spec and Details:GetSpecCoords(spec)) then
 				texturePath = [[Interface\AddOns\Details\images\spec_icons_normal]]
-				left, right, top, bottom = unpack(Details.class_specs_coords[spec])
+				left, right, top, bottom = unpack(Details:GetSpecCoords(spec))
 
 			elseif (playerObject.classe) then
 				texturePath = [[Interface\AddOns\Details\images\classes_small]]

--- a/functions/profiles.lua
+++ b/functions/profiles.lua
@@ -614,6 +614,54 @@ local default_profile = {
 		[1473] = {384/512, 448/512, 256/512, 320/512}, -- Augmentation
 	},
 
+	--spec coords for TBC/Classic, reset with: /run Details.class_classic_specs_coords = nil
+	class_classic_specs_coords = {
+		-- Warrior
+		[161] = { 448 / 512, 512 / 512, 192 / 512, 256 / 512 }, -- warrior Arms
+		[164] = { 0, 64 / 512, 256 / 512, 320 / 512 }, -- warrior Fury
+		[163] = { 64 / 512, 128 / 512, 256 / 512, 320 / 512 }, -- warrior Protection
+
+		-- Paladin
+		[382] = { 0, 64 / 512, 128 / 512, 192 / 512 },         -- paladin Holy
+		[383] = { 64 / 512, 128 / 512, 128 / 512, 192 / 512 }, -- paladin Protection
+		[381] = { (128 / 512) + 0.001953125, 192 / 512, 128 / 512, 192 / 512 }, -- paladin Retribution
+
+		-- Hunter
+		[361] = { 448 / 512, 512 / 512, 0, 64 / 512 }, -- hunter bm
+		[363] = { 0, 64 / 512, 64 / 512, 128 / 512 }, -- hunter marks
+		[362] = { 64 / 512, 128 / 512, 64 / 512, 128 / 512 }, -- hunter survival
+
+		-- Rogue
+		[182] = { 384 / 512, 448 / 512, 128 / 512, 192 / 512 }, -- rogue assassination
+		[181] = { 448 / 512, 512 / 512, 128 / 512, 192 / 512 }, -- rogue combat
+		[183] = { 0, 64 / 512, 192 / 512, 256 / 512 }, -- rogue subtlety
+
+		-- Priest
+		[201] = { 192 / 512, 256 / 512, 128 / 512, 192 / 512 },      -- priest discipline
+		[202] = { 256 / 512, 320 / 512, 128 / 512, 192 / 512 },      -- priest holy
+		[203] = { (320 / 512) + (0.001953125 * 4), 384 / 512, 128 / 512, 192 / 512 }, -- priest shadow
+
+		-- Shaman
+		[261] = { 64 / 512, 128 / 512, 192 / 512, 256 / 512 }, -- shaman elemental
+		[263] = { 128 / 512, 192 / 512, 192 / 512, 256 / 512 }, -- shaman enhancement
+		[262] = { 192 / 512, 256 / 512, 192 / 512, 256 / 512 }, -- shaman restoration
+
+		-- Mage
+		[81] = { (128 / 512) + 0.001953125, 192 / 512, 64 / 512, 128 / 512 }, -- mage arcane
+		[41] = { 192 / 512, 256 / 512, 64 / 512, 128 / 512 }, -- mage fire
+		[61] = { 256 / 512, 320 / 512, 64 / 512, 128 / 512 }, -- mage frost
+
+		-- Warlock
+		[302] = { 256 / 512, 320 / 512, 192 / 512, 256 / 512 }, -- warlock aff
+		[303] = { 320 / 512, 384 / 512, 192 / 512, 256 / 512 }, -- warlock demo
+		[301] = { 384 / 512, 448 / 512, 192 / 512, 256 / 512 }, -- warlock destro
+
+		-- Druid
+		[283] = { 192 / 512, 256 / 512, 0, 64 / 512 }, -- druid balance
+		[281] = { 256 / 512, 320 / 512, 0, 64 / 512 }, -- druid feral
+		[282] = { 384 / 512, 448 / 512, 0, 64 / 512 }, -- druid restoration
+	},
+
 	window2_data = {},
 
 	--class icons and colors
@@ -1187,6 +1235,13 @@ local default_profile = {
 }
 
 Details.default_profile = default_profile
+
+---return the spec coords table for the current game version
+---@param spec number
+---@return table
+function Details:GetSpecCoords(spec)
+	return DetailsFramework.IsTimewalkWoW() and Details.class_classic_specs_coords[spec] or Details.class_specs_coords[spec]
+end
 
 -- aqui fica as propriedades do jogador que n�o ser�o armazenadas no profile
 local default_player_data = {

--- a/functions/slash.lua
+++ b/functions/slash.lua
@@ -1339,7 +1339,7 @@ function SlashCmdList.DETAILS (msg, editbox)
 		local y = -50
 		local allspecs = {}
 
-		for a, b in pairs(Details.class_specs_coords) do
+		for a, b in pairs(DetailsFramework.IsTimewalkWoW() and Details.class_classic_specs_coords or Details.class_specs_coords) do
 			table.insert(allspecs, a)
 		end
 

--- a/plugins/Details_EncounterDetails/frames_chart.lua
+++ b/plugins/Details_EncounterDetails/frames_chart.lua
@@ -451,7 +451,7 @@ function encounterDetails:CreatePhaseIndicators(chartPanel, phaseTooltip)
 
                 if (spec) then
                     tooltipBar.icon.texture = [[Interface\AddOns\Details\images\spec_icons_normal]]
-                    tooltipBar.icon.texcoord = encounterDetails.class_specs_coords[spec]
+                    tooltipBar.icon.texcoord = Details:GetSpecCoords(spec)
 
                 elseif (class) then
                     tooltipBar.icon.texture = [[Interface\AddOns\Details\images\classes_small_alpha]]
@@ -499,7 +499,7 @@ function encounterDetails:CreatePhaseIndicators(chartPanel, phaseTooltip)
 
                 if (spec) then
                     tooltipBar.icon.texture = [[Interface\AddOns\Details\images\spec_icons_normal]]
-                    tooltipBar.icon.texcoord = encounterDetails.class_specs_coords[spec]
+                    tooltipBar.icon.texcoord = Details:GetSpecCoords(spec)
 
                 elseif (class) then
                     tooltipBar.icon:SetTexture([[Interface\AddOns\Details\images\classes_small_alpha]])

--- a/plugins/Details_Streamer/Details_Streamer.lua
+++ b/plugins/Details_Streamer/Details_Streamer.lua
@@ -986,12 +986,12 @@ local parse_target_icon = function (targetObject, target)
 			elseif (class and RAID_CLASS_COLORS [class]) then
 				if (targetObject.spec) then
 					icon2 = [[Interface\AddOns\Details\images\spec_icons_normal_alpha]]
-					icon2coords = Details.class_specs_coords [targetObject.spec]
+					icon2coords = Details:GetSpecCoords(targetObject.spec)
 				else
 					local spec_from_cache = Details.cached_specs [targetObject.serial]
 					if (spec_from_cache) then
 						icon2 = [[Interface\AddOns\Details\images\spec_icons_normal_alpha]]
-						icon2coords = Details.class_specs_coords [spec_from_cache]
+						icon2coords = Details:GetSpecCoords(spec_from_cache)
 					else
 						icon2 = [[Interface\AddOns\Details\images\classes_small_alpha]]
 						icon2coords = Details.class_coords [class]


### PR DESCRIPTION
## Description: Fix Class/Spec recognition and Icons for TBC Anniversary / Classic

I have investigated and fixed the issue regarding incorrect Class/Spec icons and role identification specifically on **TBC Anniversary** servers.

### The Problem
~~On TBC clients, the API function `GetSpecialization()` is not correctly implemented for the talent tree system. It consistently returns `1` regardless of the player's actual talent distribution.~~ 
~~* **Example:** For a Shaman, it always returns ID `261` (Elemental), even if the player has 40+ points in Enhancement or Restoration.~~
~~* This caused Protection Paladins to be misidentified as Holy, and similar issues across all classes.~~
~~* Furthermore, many hardcoded Spec IDs in the current version do not match the **Talent Tab IDs** used in the TBC Anniversary client.~~

Refined findings:
As pointed out by @flamanis, GetSpecialization() returns the index of the Dual Spec slot (1 or 2). My initial derivation was slightly off regarding the function's purpose, but the core issue remains:
The GetSpecializationInfo() call for e.g. a Shaman (with Enhancement talents) returns ID 261 (which corresponds to the first talent tab) instead of ID 263. This happens across all classes—the API doesn't dynamically return the correct SpecID based on spent points in this environment.
The Conflict: In TBC, ID 261 is a Shaman, but in the Retail-based mapping that Details! uses, ID 261 is a Subtlety Rogue.
This mismatch is the reason why Shamans icon currently appear as Rogues and Prot Paladins as Holy in the UI.

### The Solution
1. **Talent-Based Detection:** Updated the logic to prioritize talent point distribution via `GetTalentTabInfo` for TBC clients instead of relying on the faulty `GetSpecializationInfo()`.
2. **Icon Coordinates:** add `class_classic_specs_coords` array/table to ensure the correct texture crops are displayed for the newly mapped IDs.
3. **Role Assignment:** Fixed `DF.UnitGroupRolesAssigned` to bypass the Retail-only spec info calls on Classic clients.

### Request for Testing
I have verified these changes on my Shaman (Enhancement - see Attachments). Since I do not have active characters for every single class/spec combination across all game versions, I invite other contributors to double-check the mapping for their respective classes.
**Important**: These changes also need further testing in Group and Raid environments, as I haven’t had the chance to verify the role updates during active group combat or in a full raid group yet.

### TODO / Pending Tests
- [x] Verify behavior in a **party** (Group Roster Updates)
- [x] Verify behavior inside a **dungeon** (Combat Log & Instance Info)
- [x] Verify behavior in **Battlegrounds** (PVP Spec/Role updates)
- [x] Verify behavior in a **raid** (Large Roster & Raid Frame updates)

**Fixes:** Incorrect Spec/Role detection on TBC Anniversary.

before:
![Screenshot_2026-02-18_235821](https://github.com/user-attachments/assets/0bf7fbc2-a720-4de8-bdd6-ed1454c697b9)
after:
![Screenshot 2026-03-11 010749](https://github.com/user-attachments/assets/58f8ce23-f20a-4730-b945-96f61343378c)

Dungeon/Group
before:
<img width="352" height="207" alt="Screenshot 2026-03-15 143600" src="https://github.com/user-attachments/assets/2211d4af-3643-4340-a2dd-2252fc674983" />
after:
<img width="348" height="209" alt="image" src="https://github.com/user-attachments/assets/bebf7e2e-8249-4518-b4bd-3d4297e790fc" />

