### PR TITLE
Use default options window for DetailsAPI config

### DIFF
--- a/boot.lua
+++ b/boot.lua
@@ -2178,7 +2178,7 @@ function DetailsAPI:GetCurrentProfileKey()
 end
 
 function DetailsAPI:OpenConfig()
-    Details.OpenOptionsWindow()
+    Details_OpenDefaultOptionsWindow()
 end
 
 function DetailsAPI:CloseConfig()


### PR DESCRIPTION
Switch DetailsAPI:OpenConfig() to use Details_OpenDefaultOptionsWindow().