### PR TITLE
[codex] Fix profile import overwrite when reusing an existing profile

### DIFF
--- a/functions/profiles.lua
+++ b/functions/profiles.lua
@@ -2150,7 +2150,7 @@ function Details:ImportProfile (profileString, newProfileName, bImportAutoRunCod
 		--transfer instance data to the new created profile
 		profileObject.instances = DetailsFramework.table.copy({}, profileData.instances)
 
-		Details:ApplyProfile (newProfileName)
+		Details:ApplyProfile (newProfileName, overwriteExisting)
 
 		--reset automation settings (due to user not knowing why some windows are disappearing)
 		for instanceId, instance in Details:ListInstances() do

--- a/functions/profiles.lua
+++ b/functions/profiles.lua
@@ -2150,7 +2150,8 @@ function Details:ImportProfile (profileString, newProfileName, bImportAutoRunCod
 		--transfer instance data to the new created profile
 		profileObject.instances = DetailsFramework.table.copy({}, profileData.instances)
 
-		Details:ApplyProfile (newProfileName, overwriteExisting)
+		local shouldSkipSave = overwriteExisting and Details:GetCurrentProfileName() == newProfileName
+		Details:ApplyProfile (newProfileName, shouldSkipSave)
 
 		--reset automation settings (due to user not knowing why some windows are disappearing)
 		for instanceId, instance in Details:ListInstances() do


### PR DESCRIPTION
## Summary
This is a follow-up to #1076.

The previous PR made it possible for the API import path in `boot.lua` to overwrite an existing profile name. That exposed a separate bug in the overwrite path inside `Details:ImportProfile()`.

When the imported profile name already exists and is also the active profile, `ImportProfile()` copies the imported `instances` table into the target profile and then calls `Details:ApplyProfile(newProfileName)`. Because `ApplyProfile()` normally saves the current profile first, it immediately writes the live window state back into that same profile table before the imported data is applied.

In practice that means the imported `instances` / `__pos` data gets replaced with the old profile's current window positions, so importing a profile with the same name does not preserve the imported window layout.

## What changed
This PR passes `overwriteExisting` into `Details:ApplyProfile()` as `bNoSave` during profile import.

That keeps the pre-apply save step disabled only for the overwrite-import path, which preserves the imported `instances` and `__pos` tables instead of replacing them with the old live window state.

## Impact
Importing over an existing profile via the API name now keeps the imported window positions instead of restoring the positions from the profile being overwritten.

