### PR TITLE
Fix glow overlay template fallback

### DIFF
--- a/Libs/DF/fw.lua
+++ b/Libs/DF/fw.lua
@@ -4294,6 +4294,24 @@ local glow_overlay_onhide = function(self)
 	glow_overlay_stop(self)
 end
 
+local create_glow_overlay_frame = function(frameName, parent)
+	local templates
+	if (buildInfo >= 110107 or DF.IsTBCWow()) then --24-05-2025: in the 11.1.7 patch, the template used here does not exist anymore, replacement used
+		templates = {"ActionButtonSpellAlertTemplate", "ActionBarButtonSpellActivationAlert"}
+	else
+		templates = {"ActionBarButtonSpellActivationAlert", "ActionButtonSpellAlertTemplate"}
+	end
+
+	for _, templateName in ipairs(templates) do
+		local okay, glowFrame = pcall(CreateFrame, "frame", frameName, parent, templateName)
+		if (okay and glowFrame) then
+			return glowFrame
+		end
+	end
+
+	return CreateFrame("frame", frameName, parent)
+end
+
 ---create a glow overlay around a frame, return a frame and also add parent.overlay to the parent frame
 ---@param self table
 ---@param parent frame
@@ -4307,12 +4325,7 @@ function DF:CreateGlowOverlay(parent, antsColor, glowColor)
 		frameName = string.sub(frameName, string.len(frameName)-49)
 	end
 
-	local glowFrame
-	if (buildInfo >= 110107 or DF.IsTBCWow()) then --24-05-2025: in the 11.1.7 patch, the template used here does not exist anymore, replacement used
-		glowFrame = CreateFrame("frame", frameName, parent, "ActionButtonSpellAlertTemplate")
-	else
-		glowFrame = CreateFrame("frame", frameName, parent, "ActionBarButtonSpellActivationAlert")
-	end
+	local glowFrame = create_glow_overlay_frame(frameName, parent)
 
 	--local glowFrame = CreateFrame("frame", frameName, parent)
 	glowFrame:HookScript("OnShow", glow_overlay_onshow)

--- a/Libs/DF/fw.lua
+++ b/Libs/DF/fw.lua
@@ -4341,6 +4341,19 @@ local glow_overlay_onhide = function(self)
 	glow_overlay_stop(self)
 end
 
+--pick whichever spell alert template the running client actually ships, instead of guessing from the build number:
+--some clients (e.g. WoW Classic Titan) have neither the newer nor the legacy template, so CreateFrame() would
+--throw a hard "Couldn't find inherited node" error that isn't reliably catchable with pcall
+local create_glow_overlay_frame = function(frameName, parent)
+	if (DoesTemplateExist("ActionButtonSpellAlertTemplate")) then
+		return CreateFrame("frame", frameName, parent, "ActionButtonSpellAlertTemplate")
+	elseif (DoesTemplateExist("ActionBarButtonSpellActivationAlert")) then
+		return CreateFrame("frame", frameName, parent, "ActionBarButtonSpellActivationAlert")
+	else
+		return CreateFrame("frame", frameName, parent)
+	end
+end
+
 ---create a glow overlay around a frame, return a frame and also add parent.overlay to the parent frame
 ---@param self table
 ---@param parent frame
@@ -4354,12 +4367,7 @@ function DF:CreateGlowOverlay(parent, antsColor, glowColor)
 		frameName = string.sub(frameName, string.len(frameName)-49)
 	end
 
-	local glowFrame
-	if (DF.IsMidnightWowAPI() or DF.IsTBCWow()) then --24-05-2025: in the 11.1.7 patch, the template used here does not exist anymore, replacement used
-		glowFrame = CreateFrame("frame", frameName, parent, "ActionButtonSpellAlertTemplate")
-	else
-		glowFrame = CreateFrame("frame", frameName, parent, "ActionBarButtonSpellActivationAlert")
-	end
+	local glowFrame = create_glow_overlay_frame(frameName, parent)
 
 	--local glowFrame = CreateFrame("frame", frameName, parent)
 	glowFrame:HookScript("OnShow", glow_overlay_onshow)

--- a/frames/window_wa.lua
+++ b/frames/window_wa.lua
@@ -2420,12 +2420,9 @@ function _detalhes:OpenAuraPanel (spellid, spellname, spellicon, encounterid, tr
         local useglow_label = fw:CreateLabel(f, "Glow Effect: ", nil, nil, "GameFontNormal")
         local useglow = fw:CreateSwitch(f, function(self, _, state) 
             if (state and self.glow_test) then  
-                self.glow_test:Show()
-                self.glow_test.animOut:Stop()
-                self.glow_test.animIn:Play()
+                self.glow_test:Play()
             elseif (self.glow_test) then
-                self.glow_test.animIn:Stop()
-                self.glow_test.animOut:Play()
+                self.glow_test:Stop()
             end 
         end, false, nil, nil, nil, nil, "UseGlow")
         
@@ -2435,7 +2432,8 @@ function _detalhes:OpenAuraPanel (spellid, spellname, spellicon, encounterid, tr
         useglow:SetPoint("left", useglow_label, "right", 2, 0)
         useglow.tooltip = "Do not rename the aura on WeakAuras options panel or the glow effect may not work."
         
-        useglow.glow_test = CreateFrame("frame", "DetailsAuraTextGlowTest", useglow.widget, "ActionBarButtonSpellActivationAlert")
+        useglow.glow_test = fw:CreateGlowOverlay(useglow.widget, "yellow", "white")
+        useglow.glow_test:ClearAllPoints()
         useglow.glow_test:SetPoint("topleft", useglow.widget, "topleft", -20, 2)
         useglow.glow_test:SetPoint("bottomright", useglow.widget, "bottomright", 20, -2)
         useglow.glow_test:Hide()
@@ -2753,8 +2751,7 @@ function _detalhes:OpenAuraPanel (spellid, spellname, spellicon, encounterid, tr
     DetailsAuraPanel.AuraSpellId.text = tostring(spellid)
     DetailsAuraPanel.icon.texture = spellicon
     
-    DetailsAuraPanel.UseGlow.glow_test.animIn:Stop()
-    DetailsAuraPanel.UseGlow.glow_test.animOut:Play()
+    DetailsAuraPanel.UseGlow.glow_test:Stop()
     DetailsAuraPanel.UseGlow:SetValue(false)
     
     DetailsAuraPanel.StackSlider:SetValue(0)


### PR DESCRIPTION
## Why
On WoW Classic Titan 3.8.0.1 (build 67400, TOC 38001), Details fails during load with:

```lua
CreateFrame(): Couldn't find inherited node "ActionBarButtonSpellActivationAlert"
Details/Libs/DF/fw.lua:4314: in function 'CreateGlowOverlay'
Details/frames/window_main.lua:3536
```

The addon already has version-aware handling for Blizzard's spell alert templates, but Classic Titan can still hit the older `ActionBarButtonSpellActivationAlert` path even though that inherited template is unavailable in this client. The result is a hard load-time error instead of just a missing glow animation.

## Summary
- keep the existing per-version preferred spell alert template selection for glow overlays
- fall back to the alternate Blizzard glow template only when the preferred inherited template is missing
- route the WeakAuras glow preview through `CreateGlowOverlay()` so it uses the same guarded template selection

## Verification
- Compared the local addon files against `Tercioo/Details-Damage-Meter:master`; the PR diff only contains the glow fallback changes.
- Verified in game on WoW Classic Titan 3.8.0.1, build 67400, TOC 38001, ProjectID 11.
- Confirmed `/reload` no longer raises the missing `ActionBarButtonSpellActivationAlert` inherited-node error.

## Compatibility notes
This intentionally preserves the current preferred template order for existing clients: 11.1.7+ and TBC still try `ActionButtonSpellAlertTemplate` first, while other clients still try `ActionBarButtonSpellActivationAlert` first. The alternate template and plain-frame fallback are only used when the preferred template is unavailable.