### PR TITLE
fix(container_actors): convert secret actorName to plain string in GetOrCreateActor for Midnight 12.0

### DIFF
--- a/classes/container_actors.lua
+++ b/classes/container_actors.lua
@@ -892,6 +892,13 @@ unitNameTitles[#unitNameTitles+1] = unitNameTitles[1]:gsub(PET_TYPE_PET, PET_TYP
 		local petOwnerObject
 		actorSerial = actorSerial or "ns"
 
+		-- Midnight 12.0: actorName from C_DamageMeter / UnitName can be a
+		-- secret string, which cannot be used as a regular table key or
+		-- stored on non-secret-safe tables. Convert to plain string early.
+		if type(actorName) == "string" and ToPlainString then
+			actorName = ToPlainString(actorName)
+		end
+
 		if not detailsFramework.IsAddonApocalypseWow() then
 			--check if this actor is a pet and the pet is in the pet cache
 			if (petContainer.IsPetInCache(actorSerial)) then --this is a registered pet


### PR DESCRIPTION
In Midnight 12.0, player names from `C_DamageMeter` and `UnitName` can be **secret strings**, which cannot be used as keys for regular Lua tables.

Details stores actor names in `self._NameIndexTable[actorName]` (line 936) and on actor frames (`newActor.nome = actorName`). This causes:
> `attempted to index a table that cannot be indexed with secret keys`

**Fix:** Call `ToPlainString(actorName)` early in `GetOrCreateActor`, before any table indexing or storage. Guarded with `type` and nil checks for pre-12.0 compatibility.

**Testing:** 17 repeated errors resolved after applying the fix.