### PR TITLE
Guard secret damage-taken actor names

### DIFF
--- a/core/parser_nocleu1.lua
+++ b/core/parser_nocleu1.lua
@@ -997,6 +997,11 @@ local addOverallAsSegment = function()
         local actorList = Details222.B.GetSegmentInfo(segments[8])
         for i = 1, #actorList do
             local thisActor = actorList[i]
+
+            if (issecretvalue(thisActor.name)) then
+                return
+            end
+
             local actor = damageContainer:GetOrCreateActor(thisActor.sourceGUID, thisActor.name, 0x512, true)
             actor.nome = thisActor.name
             actor.damage_taken = thisActor.totalAmount
@@ -1279,6 +1284,11 @@ local addSegment = function(parameterType, session, bIsUpdate, detailsId)
         local actorList = Details222.B.GetSegmentInfo(segments[8])
         for i = 1, #actorList do
             local thisActor = actorList[i]
+
+            if (issecretvalue(thisActor.name)) then
+                return
+            end
+
             local actor = damageContainer:GetOrCreateActor(thisActor.sourceGUID, thisActor.name, 0x512, true)
             actor.nome = thisActor.name
             actor.damage_taken = thisActor.totalAmount


### PR DESCRIPTION
## Problem

A damage-taken actor name can still be secret when the Blizzard damage-meter session callback runs. Passing it to `GetOrCreateActor` makes Details index `_NameIndexTable` with a secret key:

```
classes/container_actors.lua:936:
attempted to index a table that cannot be indexed with secret keys
```

## Fix

Apply the same `issecretvalue` guard already used for damage-done actors to both damage-taken parsing paths. Parsing stops before a secret name reaches the actor-name map.

## Tested

- Retail 12.0.7 / Details.20260707.15250.172.
- Reproduced before the change while parsing a Blizzard damage-meter segment.
- After `/reload`, the same flow no longer produces the error.
- `git diff --check` passes.