### PR TITLE
Fix arena summary crash when OnArenaStart never ran for the match

### DIFF
--- a/frames/window_arenasummary.lua
+++ b/frames/window_arenasummary.lua
@@ -367,6 +367,13 @@ function ArenaSummary.OnArenaEnd() --~end
         return
     end
 
+    --combatData is only built by OnArenaStart(); if that never ran for this match
+    --(e.g. a /reload or enabling the addon while already inside the arena), there is
+    --nothing to summarize and the combatData.* accesses below would error. Bail out.
+    if (not Details222.ArenaSummary.arenaData.combatData) then
+        return
+    end
+
     local combat = Details:GetCurrentCombat()
     local combatTime = combat:GetCombatTime()
     if (Details.arena_debug) then


### PR DESCRIPTION
### Problem

`ArenaSummary.OnArenaEnd()` in `frames/window_arenasummary.lua` unconditionally
indexes `Details222.ArenaSummary.arenaData.combatData` — it sets
`combatData.teamInfos` and iterates `combatData.groupMembers`. But `combatData`
is only ever created by `OnArenaStart()`; the module's default state is a bare
`arenaData = {}`.

If `OnArenaStart()` never ran for the current match, `OnArenaEnd()` throws:

`attempt to perform indexed assignment on field 'combatData' (a nil value)`

The easiest way to reproduce is to **`/reload` (or enable Details) while already
inside an arena** — the addon misses `OnArenaStart` for that match, then errors
the moment the arena ends.

### Fix

Bail out early in `OnArenaEnd()` when `combatData` is `nil` — there is nothing
to summarize without it. The guard is placed right after the existing
`IsAddonApocalypseWow()` check, before the first `combatData` access.

```lua
if (not Details222.ArenaSummary.arenaData.combatData) then
    return
end
```

Minimal and side-effect-free: normal arenas (where OnArenaStart ran) are
unaffected; only the broken-state path is short-circuited.

### Notes

Found on Mists of Pandaria Classic (5.5.4), but the crashing function is
identical on master, so this affects retail as well.
