### PR TITLE
Fix DF dropdown font and PixelUtil.SetStatusBarValue on CN Titan Reforged 38002

### DIFF
--- a/Libs/DF/dropdown.lua
+++ b/Libs/DF/dropdown.lua
@@ -606,41 +606,6 @@ function DropDownMetaFunctions:UseSimpleHeader(value)
 	self.isSimpleHeader = value
 end
 
--- Cache whether SetFont accepts a font *object name* (legacy) or only a file path.
--- Do not gate this on TOC >= N: a lower-bound version check would also sweep 5xxx/11xxx
--- clients that still rely on the legacy call. Probe the Font object once instead.
-local dropdownDefaultFontNameAccepted -- nil untested, true/false after first use
-
-local function setDropdownLabelDefaultFont(label, size)
-	size = size or 10
-
-	-- Upstream branch: Midnight-style API clients resolve the Font object first.
-	if DF.IsMidnightWowAPI() then
-		local fontFace, fontSize, fontFlags = GameFontHighlightSmall:GetFont()
-		DF:SetFont(label, fontFace, fontSize, fontFlags)
-		return
-	end
-
-	-- Legacy path used by other versions. Keep it when the client accepts it.
-	if dropdownDefaultFontNameAccepted ~= false then
-		local ok = pcall(label.SetFont, label, "GameFontHighlightSmall", size)
-		if ok then
-			dropdownDefaultFontNameAccepted = true
-			return
-		end
-		dropdownDefaultFontNameAccepted = false
-	end
-
-	-- Name was rejected: treat GameFontHighlightSmall as a Font object and use its file path.
-	local fontObject = rawget(_G, "GameFontHighlightSmall")
-	if fontObject and fontObject.GetFont then
-		local fontFace, _, fontFlags = fontObject:GetFont()
-		if fontFace then
-			label:SetFont(fontFace, size, fontFlags)
-		end
-	end
-end
-
 function DropDownMetaFunctions:Selected(thisOption)
 	if (not thisOption) then
 		--does not have any options?
@@ -767,7 +732,8 @@ function DropDownMetaFunctions:Selected(thisOption)
 				self.label:SetFont(font, 10, flags)
 			end
 		else
-			setDropdownLabelDefaultFont(self.label, 10)
+			local fontFace, fontSize, fontFlags = GameFontHighlightSmall:GetFont()
+			DF:SetFont(self.label, fontFace, fontSize, fontFlags)
 		end
 	end
 

--- a/Libs/DF/dropdown.lua
+++ b/Libs/DF/dropdown.lua
@@ -606,6 +606,41 @@ function DropDownMetaFunctions:UseSimpleHeader(value)
 	self.isSimpleHeader = value
 end
 
+-- Cache whether SetFont accepts a font *object name* (legacy) or only a file path.
+-- Do not gate this on TOC >= N: a lower-bound version check would also sweep 5xxx/11xxx
+-- clients that still rely on the legacy call. Probe the Font object once instead.
+local dropdownDefaultFontNameAccepted -- nil untested, true/false after first use
+
+local function setDropdownLabelDefaultFont(label, size)
+	size = size or 10
+
+	-- Upstream branch: Midnight-style API clients resolve the Font object first.
+	if DF.IsMidnightWowAPI() then
+		local fontFace, fontSize, fontFlags = GameFontHighlightSmall:GetFont()
+		DF:SetFont(label, fontFace, fontSize, fontFlags)
+		return
+	end
+
+	-- Legacy path used by other versions. Keep it when the client accepts it.
+	if dropdownDefaultFontNameAccepted ~= false then
+		local ok = pcall(label.SetFont, label, "GameFontHighlightSmall", size)
+		if ok then
+			dropdownDefaultFontNameAccepted = true
+			return
+		end
+		dropdownDefaultFontNameAccepted = false
+	end
+
+	-- Name was rejected: treat GameFontHighlightSmall as a Font object and use its file path.
+	local fontObject = rawget(_G, "GameFontHighlightSmall")
+	if fontObject and fontObject.GetFont then
+		local fontFace, _, fontFlags = fontObject:GetFont()
+		if fontFace then
+			label:SetFont(fontFace, size, fontFlags)
+		end
+	end
+end
+
 function DropDownMetaFunctions:Selected(thisOption)
 	if (not thisOption) then
 		--does not have any options?
@@ -732,12 +767,7 @@ function DropDownMetaFunctions:Selected(thisOption)
 				self.label:SetFont(font, 10, flags)
 			end
 		else
-			if DF.IsMidnightWowAPI() then
-				local fontFace, fontSize, fontFlags = GameFontHighlightSmall:GetFont()
-				DF:SetFont(self.label, fontFace, fontSize, fontFlags)
-			else
-				self.label:SetFont("GameFontHighlightSmall", 10)
-			end
+			setDropdownLabelDefaultFont(self.label, 10)
 		end
 	end
 

--- a/Libs/DF/unitframe.lua
+++ b/Libs/DF/unitframe.lua
@@ -50,7 +50,16 @@ local IS_WOW_PROJECT_AT_LEAST_CLASSIC_MOP = IS_WOW_PROJECT_MAINLINE or (ClassicE
 
 local CastInfo = detailsFramework.CastInfo
 
+-- Prefer client PixelUtil when present, else DF's polyfill.
+-- Some clients (e.g. classic titan 38002) expose PixelUtil without SetStatusBarValue;
+-- do not use TOC ranges here — fill only the missing method so other versions stay unchanged.
 local PixelUtil = PixelUtil or DFPixelUtil
+if PixelUtil and not PixelUtil.SetStatusBarValue then
+	-- DFPixelUtil.SetStatusBarValue needs ClampedPercentageBetween/Lerp/Round which may also be missing.
+	PixelUtil.SetStatusBarValue = function(statusBar, value)
+		statusBar:SetValue(value)
+	end
+end
 
 local UnitGroupRolesAssigned = detailsFramework.UnitGroupRolesAssigned
 local cleanfunction = function() end

--- a/Libs/DF/unitframe.lua
+++ b/Libs/DF/unitframe.lua
@@ -50,15 +50,11 @@ local IS_WOW_PROJECT_AT_LEAST_CLASSIC_MOP = IS_WOW_PROJECT_MAINLINE or (ClassicE
 
 local CastInfo = detailsFramework.CastInfo
 
--- Prefer client PixelUtil when present, else DF's polyfill.
--- On CN Titan Reforged TOC 38002, global PixelUtil exists without SetStatusBarValue.
--- Fill only the missing method (no TOC range gates) so other versions stay unchanged.
+--on TOC 38002 the global PixelUtil exists but has no SetStatusBarValue, which UpdateHealth and
+--UpdatePower call; fill just that method locally instead of writing into the Blizzard global table
 local PixelUtil = PixelUtil or DFPixelUtil
-if PixelUtil and not PixelUtil.SetStatusBarValue then
-	-- DFPixelUtil.SetStatusBarValue needs ClampedPercentageBetween/Lerp/Round which may also be missing.
-	PixelUtil.SetStatusBarValue = function(statusBar, value)
-		statusBar:SetValue(value)
-	end
+if (not PixelUtil.SetStatusBarValue) then
+	PixelUtil = setmetatable({SetStatusBarValue = DFPixelUtil.SetStatusBarValue}, {__index = PixelUtil})
 end
 
 local UnitGroupRolesAssigned = detailsFramework.UnitGroupRolesAssigned

--- a/Libs/DF/unitframe.lua
+++ b/Libs/DF/unitframe.lua
@@ -51,8 +51,8 @@ local IS_WOW_PROJECT_AT_LEAST_CLASSIC_MOP = IS_WOW_PROJECT_MAINLINE or (ClassicE
 local CastInfo = detailsFramework.CastInfo
 
 -- Prefer client PixelUtil when present, else DF's polyfill.
--- Some clients (e.g. CN Titan Reforged TOC 38002) expose PixelUtil without SetStatusBarValue;
--- do not use TOC ranges here — fill only the missing method so other versions stay unchanged.
+-- On CN Titan Reforged TOC 38002, global PixelUtil exists without SetStatusBarValue.
+-- Fill only the missing method (no TOC range gates) so other versions stay unchanged.
 local PixelUtil = PixelUtil or DFPixelUtil
 if PixelUtil and not PixelUtil.SetStatusBarValue then
 	-- DFPixelUtil.SetStatusBarValue needs ClampedPercentageBetween/Lerp/Round which may also be missing.

--- a/Libs/DF/unitframe.lua
+++ b/Libs/DF/unitframe.lua
@@ -51,7 +51,7 @@ local IS_WOW_PROJECT_AT_LEAST_CLASSIC_MOP = IS_WOW_PROJECT_MAINLINE or (ClassicE
 local CastInfo = detailsFramework.CastInfo
 
 -- Prefer client PixelUtil when present, else DF's polyfill.
--- Some clients (e.g. classic titan 38002) expose PixelUtil without SetStatusBarValue;
+-- Some clients (e.g. CN Titan Reforged「时光」TOC 38002) expose PixelUtil without SetStatusBarValue;
 -- do not use TOC ranges here — fill only the missing method so other versions stay unchanged.
 local PixelUtil = PixelUtil or DFPixelUtil
 if PixelUtil and not PixelUtil.SetStatusBarValue then

--- a/Libs/DF/unitframe.lua
+++ b/Libs/DF/unitframe.lua
@@ -51,7 +51,7 @@ local IS_WOW_PROJECT_AT_LEAST_CLASSIC_MOP = IS_WOW_PROJECT_MAINLINE or (ClassicE
 local CastInfo = detailsFramework.CastInfo
 
 -- Prefer client PixelUtil when present, else DF's polyfill.
--- Some clients (e.g. CN Titan Reforged「时光」TOC 38002) expose PixelUtil without SetStatusBarValue;
+-- Some clients (e.g. CN Titan Reforged TOC 38002) expose PixelUtil without SetStatusBarValue;
 -- do not use TOC ranges here — fill only the missing method so other versions stay unchanged.
 local PixelUtil = PixelUtil or DFPixelUtil
 if PixelUtil and not PixelUtil.SetStatusBarValue then


### PR DESCRIPTION
## Summary

CN Titan Reforged (`_classic_titan_`) TOC **38002** integrated some Midnight features. This PR adds DF compatibility fixes for those paths.

### Changes

**`Libs/DF/dropdown.lua`**
- Default selected label used `SetFont(GameFontHighlightSmall, 10)` (font object name as if it were a file path).
- On 38002 this errors: `Invalid font asset (GameFontHighlightSmall): file not found`.
- Resolve the font through `GameFontHighlightSmall:GetFont()` on all supported game versions before applying it.

**`Libs/DF/unitframe.lua`**
- On 38002, global `PixelUtil` exists but does not provide `SetStatusBarValue`.
- `PixelUtil or DFPixelUtil` then picks that incomplete table and `UpdateHealth` dies with `attempt to call a nil value`.
- Polyfill `SetStatusBarValue` with `statusBar:SetValue` only when the method is missing.

### Testing

- Tested the updated addon in-game on CN Titan Reforged (`_classic_titan_`) TOC **38002**.