### PR TITLE
Apply context alpha on retail

### DIFF
--- a/frames/window_main.lua
+++ b/frames/window_main.lua
@@ -5589,6 +5589,10 @@ function Details:SetWindowAlphaForCombat(enteringInCombat, trueHide, alphaAmount
 		if not Details:IsUsingBlizzardAPI() then
 			Details.FadeHandler.Fader(self.rowframe, "ALPHAANIM", parseRowFrameAlpha(rowsamount))
 			Details.FadeHandler.Fader(self.baseframe, "ALPHAANIM", rowsamount)
+		else
+			-- both frames were just raised to maxAlpha above
+			self.rowframe:SetAlpha(parseRowFrameAlpha(rowsamount))
+			self.baseframe:SetAlpha(rowsamount)
 		end
 	end
 


### PR DESCRIPTION
A window with a hide-on-context rule comes up fully opaque after login or
/reload and stays that way until the cursor enters and leaves it once.

Repro: window options -> Auto Hide -> "While Out of Combat" enabled with alpha
10%. /reload while out of combat and the window sits at 100%. Hover it and move
away: it drops to 10% and behaves for the rest of the session.
