### PR TITLE
Fix comparison refresh before header initialization

### DIFF
--- a/frames/window_breakdown_midnight/section_compare.lua
+++ b/frames/window_breakdown_midnight/section_compare.lua
@@ -414,6 +414,11 @@ end
 local refreshCompareSection = function(self, data, offset, totalLines)
     local header = self.Header
     local headerTable = header:GetHeaderTable() or {}
+
+    if not header:DoesColumnExists(2) then --wait the first refresh
+        return
+    end
+
     local nameColumnWidth = header:GetColumnWidth(2) or 0
     local activeComparisonColumns = self.ActiveComparisonColumns or 1
     local defaultTextColor = Details.breakdown_general.font_color


### PR DESCRIPTION
## Summary

- Skip comparison-scroll refresh until its dynamic header has initialized the second column.
- Prevent `Header:GetColumnWidth(2)` from asserting when a size change causes a nested refresh while the breakdown window is opening.

## Root cause

`CreateSectionScroll` initially creates each section header with one placeholder column. `CompareScrollInit` later builds the real comparison header, but `buildHeaderData` reads `sectionFrame:GetWidth()`. Resolving that layout can invoke `OnSizeChanged`, which calls `scrollBox:Refresh()` before `UpdateSectionHeader` replaces the placeholder header. `refreshCompareSection` then unconditionally reads column 2 and asserts because it does not exist yet.

The new guard matches the existing initialization guards used by the segment and player resize handlers.

## Testing

- `git diff --check`
- Focused source check verifies the initialization guard occurs before the first `GetColumnWidth(2)` read in `refreshCompareSection`
- Not tested in-game
